### PR TITLE
Code cleanup

### DIFF
--- a/css/ryht-internal-style.css
+++ b/css/ryht-internal-style.css
@@ -47,7 +47,7 @@ img {
 	z-index : 1;
     left: 0;
 	bottom: 0;
-	font-family: "Helvetica Neue", helvetica, arial, sans-serif;	
+	font-family: "Helvetica Neue", helvetica, arial, sans-serif;
 	font-weight: normal;
 	color: #363635;
 	text-decoration: none;
@@ -67,7 +67,7 @@ img {
 	z-index : 1;
     right: 0;
 	bottom: 0;
-	font-family: "Montserrat", helvetica, arial, sans-serif;	
+	font-family: "Montserrat", helvetica, arial, sans-serif;
 	font-weight: normal;
 	color: #363635;
 	text-decoration: none;
@@ -96,7 +96,7 @@ ul{
     margin-bottom: 5px;
     padding: 0;
     float: left;
-    list-style: none; 
+    list-style: none;
     }
   .legend .legend-scale ul li {
     font-size: 80%;
@@ -114,11 +114,11 @@ ul{
     margin-left: 0px;
     border: 0px solid #999;
     }
-	
+
 	.inactive {
 		opacity: 0.25;
 	}
-	
+
 #raising_blended_learners
 {
 	background:url(../markers/raising_blended_learners.svg) left center;
@@ -126,7 +126,7 @@ ul{
 	height:12px;
 	display: block;
 	float: left;
-}	
+}
 #raising_family_partnerships
 {
 	background:url(../markers/raising_family_partnerships.svg) left center;
@@ -142,7 +142,7 @@ ul{
 	height:14px;
 	display: block;
 	float: left;
-}	
+}
 #raising_texas_teachers
 {
 	background:url(../markers/raising_texas_teachers.svg) left center;
@@ -196,17 +196,17 @@ ul{
     color: #999;
     clear: both;
     }
-	
+
   .legend .map-credit {
     font-size: 70%;
     color: #999;
     clear: both;
     }
-	
+
   .legend a {
     color: #777;
     }
-	
+
 	a:link {
     text-decoration: none;
 }

--- a/css/ryht-internal-style.css
+++ b/css/ryht-internal-style.css
@@ -167,6 +167,14 @@ ul{
 	display: block;
 	float: left;
 }
+#districts_of_innovation_poly
+{
+	background:url(../markers/districts_of_innovation_poly.svg) left center;
+	width:14px;
+	height:14px;
+	display: block;
+	float: left;
+}
 #texas_school_districts
 {
 	background:url(../markers/texas_school_districts.svg) left center;

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -268,10 +268,14 @@
 		console.log(params);
 		if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
 			var visibilityState = 'none';
-			document.getElementById(params.legendID).classList.add('inactive');
+			if ((params.legendID !== undefined) && (params.legendID !== false)) {
+				document.getElementById(params.legendID).classList.add('inactive');
+			}
 		}	else {
 			var visibilityState = 'visible';
-			document.getElementById(params.legendID).classList.remove('inactive');
+			if ((params.legendID !== undefined) && (params.legendID !== false)) {
+				document.getElementById(params.legendID).classList.remove('inactive');
+			}
 		}
 		map.addSource(params.sourceName, {
 			type: 'vector',
@@ -318,11 +322,12 @@
 	/*
 		How to add point layers using the GUS API:
 		Call the addPointLayer() function with arguments like the examples below.  The final argument is optional: set it to true if you want the layer visible before the user does anything; otherwise it's hidden until they click to activate it.
+
+		How to add vector layers using Mapbox:
+		Call the addVectorLayer() function with arguments like the examples below.  Note that these calls have to be after the addPointLayer() ones, because they will reference at least one of the point layers as a way of making sure polygons get drawn behind points.
 	*/
 
 	map.on('load', function () {
-
-// params: gusID, sourceName, layerName, icon, iconSize, legendID, visibleOnLoad
 		addPointLayer(
 			map,
 			{
@@ -331,7 +336,7 @@
 				'layerName': 'raising-family-partnerships-points', // layer name
 				'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
 				'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
-				'legendID': 'raising_family_partnerships', // this one will be the id in the legend
+				'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
 				'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
 			}
 		);
@@ -445,15 +450,15 @@
 		addVectorLayer(
 			map,
 			{
-				'sourceName': 'texas-school-districts',
-				'sourceID': 'texas_school_districts_v2',
-				'sourceURL': 'mapbox://core-gis.e4af0de1',
-				'lineLayerName': 'texas-school-districts-lines',
-				'lineColor': '#a1b082',
-				'legendID': 'texas_school_districts',
-				'displayBehind': 'districts-of-innovation-points',
-				'polygonLayerName': 'texas-school-districts-poly',
-				'visibleOnLoad': false
+				'sourceName': 'texas-school-districts', // data source name for internal use
+				'sourceID': 'texas_school_districts_v2', // name of the Mapbox layer from which the data will be loaded
+				'sourceURL': 'mapbox://core-gis.e4af0de1', // Mapbox URL
+				'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines.  Leave out or set to false if you don't want outlines displayed.
+				'lineColor': '#a1b082', // colour to draw those outlines with; safe to leave out if we're not drawing outlines, but must be explicitly set if we are
+				'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
+				'displayBehind': 'districts-of-innovation-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
+				'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.  Leave out or set to false if you don't want one.
+				'visibleOnLoad': false // set this optional argument to true to have the layer visible on load.  Leave out or set to false to have it hidden on load
 			}
 		);
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -14,600 +14,589 @@
 		2) a populateZoomControl() line in the runWhenLoadComplete() function
 -->
 
-<head>
+	<head>
     <meta charset='utf-8' />
     <title>Raise Your Hand Texas Internal Web Map</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
-	<link href="css/ryht-internal-style.css" rel="stylesheet">
-    <style>
-        body { margin:0; padding:0; }
-        #map { position:absolute; top:0; bottom:0; width:100%; }
-		.mapboxgl-popup {
-		max-width: 400px;
-		font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
-}
-</style>
-
-	<script>
-		function showHideLayer(layerName, markerName) {
-			var visibility = map.getLayoutProperty(layerName, 'visibility');
-        if (visibility === 'visible') {
-					map.setLayoutProperty(layerName, 'visibility', 'none');
-					this.className = '';
-				document.getElementById(markerName).classList.add('inactive');
-        } else {
-					this.className = 'active';
-					map.setLayoutProperty(layerName, 'visibility', 'visible');
-				document.getElementById(markerName).classList.remove('inactive');
+		<link href="css/ryht-internal-style.css" rel="stylesheet" />
+		<style>
+			body { margin:0; padding:0; }
+			#map { position:absolute; top:0; bottom:0; width:100%; }
+			.mapboxgl-popup {
+				max-width: 400px;
+				font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
 			}
-		}
+		</style>
 
-//These are the four functions written by Eldan that power the zoom-to-district feature
-// runWhenLoadComplete() checks if the map has finished loading data, and once it has then it calls the next one.
-//populateZoomControl() fills the dropdowns with options generated from reading the data layers for all the district names.
-//getIDsList() does the actual work of fetching the district names
-//zoomToPolygon() zooms the map to the district extent
-
-		function runWhenLoadComplete() {
-			if (!map.loaded()) {
-				setTimeout(runWhenLoadComplete, 100);
-			}
-			else {
-				populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
-				populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
-				populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
-			}
-		}
-
-		function populateZoomControl(selectID, sourceID, fieldName, layerName) {
-			polygonNames = getIDsList(sourceID, fieldName);
-			var select = document.getElementById(selectID);
-			select.options[0] = new Option(layerName);
-			for (i in polygonNames) {
-				select.options[select.options.length] = new Option(polygonNames[i], polygonNames[i]);
-			}
-		}
-
-		function getIDsList(sourceID, fieldName) {
-			layerID = map.getSource(sourceID).vectorLayerIds[0];
-			features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
-			featureNames = []
-			for (i in features) {
-				featureName = features[i].properties[fieldName]
-				if (typeof featureName !== undefined) {
-					if (featureNames.indexOf(featureName) < 0) {
-						featureNames.push(featureName);
-					}
+		<script>
+			function showHideLayer(layerName, markerName) {
+				var visibility = map.getLayoutProperty(layerName, 'visibility');
+					if (visibility === 'visible') {
+						map.setLayoutProperty(layerName, 'visibility', 'none');
+						this.className = '';
+					document.getElementById(markerName).classList.add('inactive');
+					} else {
+						this.className = 'active';
+						map.setLayoutProperty(layerName, 'visibility', 'visible');
+					document.getElementById(markerName).classList.remove('inactive');
 				}
 			}
-			// if the IDs are numeric we have to make sure they get sorted as numbers not as text
-			if (typeof featureNames[0] !== undefined && !isNaN(parseFloat(featureNames[0])) && isFinite(featureNames[0])) {
-				return featureNames.sort(function(a, b){return a-b});
-			}
-			else { return featureNames.sort(); }
-		}
 
-		function zoomToPolygon(sourceID, itemID, fieldName) {
-			// first quickly zoom out to the full layer area
-			map.fitBounds(map.getSource(sourceID).bounds, options={duration: 0});
-			// if we haven't passed in an itemID, then just stop there; otherwise continue with the zoom in
-			if (typeof itemID !== 'undefined') {
-				// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
-				setTimeout(
-					function(){
-						layerBounds = map.getSource(sourceID).bounds;
-						layerID = map.getSource(sourceID).vectorLayerIds[0];
-						features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
-						minX = layerBounds[2];
-						maxX = layerBounds[0];
-						minY = layerBounds[3];
-						maxY = layerBounds[1];
-						// then step through features - first to find the item we want
-						for (i in features) {
-							if (features[i].properties[fieldName] == itemID) {
-								coords = features[i].toJSON().geometry.coordinates;
-								for (j in coords) {
-									// then the coords returned may be a simple array of coords, or an array of arrays if it's a multipolygon
-									for (k in coords[j]) {
-										if (!(coords[j][k][0] instanceof Array)) {
-											if (coords[j][k][0] < minX) { minX = coords[j][k][0]; }
-											if (coords[j][k][0] > maxX) { maxX = coords[j][k][0]; }
-											if (coords[j][k][1] < minY) { minY = coords[j][k][1]; }
-											if (coords[j][k][1] > maxY) { maxY = coords[j][k][1]; }
-										}
-										else {
-											for (l in coords[j][k]) {
-												if (coords[j][k][l][0] < minX) { minX = coords[j][k][l][0]; }
-												if (coords[j][k][l][0] > maxX) { maxX = coords[j][k][l][0]; }
-												if (coords[j][k][l][1] < minY) { minY = coords[j][k][l][1]; }
-												if (coords[j][k][l][1] > maxY) { maxY = coords[j][k][l][1]; }
+	//These are the four functions written by Eldan that power the zoom-to-district feature
+	// runWhenLoadComplete() checks if the map has finished loading data, and once it has then it calls the next one.
+	//populateZoomControl() fills the dropdowns with options generated from reading the data layers for all the district names.
+	//getIDsList() does the actual work of fetching the district names
+	//zoomToPolygon() zooms the map to the district extent
+
+			function runWhenLoadComplete() {
+				if (!map.loaded()) {
+					setTimeout(runWhenLoadComplete, 100);
+				}
+				else {
+					populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
+					populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
+					populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
+				}
+			}
+
+			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
+				polygonNames = getIDsList(sourceID, fieldName);
+				var select = document.getElementById(selectID);
+				select.options[0] = new Option(layerName);
+				for (i in polygonNames) {
+					select.options[select.options.length] = new Option(polygonNames[i], polygonNames[i]);
+				}
+			}
+
+			function getIDsList(sourceID, fieldName) {
+				layerID = map.getSource(sourceID).vectorLayerIds[0];
+				features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
+				featureNames = []
+				for (i in features) {
+					featureName = features[i].properties[fieldName]
+					if (typeof featureName !== undefined) {
+						if (featureNames.indexOf(featureName) < 0) {
+							featureNames.push(featureName);
+						}
+					}
+				}
+				// if the IDs are numeric we have to make sure they get sorted as numbers not as text
+				if (typeof featureNames[0] !== undefined && !isNaN(parseFloat(featureNames[0])) && isFinite(featureNames[0])) {
+					return featureNames.sort(function(a, b){return a-b});
+				}
+				else { return featureNames.sort(); }
+			}
+
+			function zoomToPolygon(sourceID, itemID, fieldName) {
+				// first quickly zoom out to the full layer area
+				map.fitBounds(map.getSource(sourceID).bounds, options={duration: 0});
+				// if we haven't passed in an itemID, then just stop there; otherwise continue with the zoom in
+				if (typeof itemID !== 'undefined') {
+					// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
+					setTimeout(
+						function(){
+							layerBounds = map.getSource(sourceID).bounds;
+							layerID = map.getSource(sourceID).vectorLayerIds[0];
+							features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
+							minX = layerBounds[2];
+							maxX = layerBounds[0];
+							minY = layerBounds[3];
+							maxY = layerBounds[1];
+							// then step through features - first to find the item we want
+							for (i in features) {
+								if (features[i].properties[fieldName] == itemID) {
+									coords = features[i].toJSON().geometry.coordinates;
+									for (j in coords) {
+										// then the coords returned may be a simple array of coords, or an array of arrays if it's a multipolygon
+										for (k in coords[j]) {
+											if (!(coords[j][k][0] instanceof Array)) {
+												if (coords[j][k][0] < minX) { minX = coords[j][k][0]; }
+												if (coords[j][k][0] > maxX) { maxX = coords[j][k][0]; }
+												if (coords[j][k][1] < minY) { minY = coords[j][k][1]; }
+												if (coords[j][k][1] > maxY) { maxY = coords[j][k][1]; }
+											}
+											else {
+												for (l in coords[j][k]) {
+													if (coords[j][k][l][0] < minX) { minX = coords[j][k][l][0]; }
+													if (coords[j][k][l][0] > maxX) { maxX = coords[j][k][l][0]; }
+													if (coords[j][k][l][1] < minY) { minY = coords[j][k][l][1]; }
+													if (coords[j][k][l][1] > maxY) { maxY = coords[j][k][l][1]; }
+												}
 											}
 										}
 									}
 								}
 							}
-						}
-						// having found the bounds, the rest is easy
-						map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
-					},
-					100
-				); // end of setTimeout block
+							// having found the bounds, the rest is easy
+							map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
+						},
+						100
+					); // end of setTimeout block
+				}
 			}
-		}
-	</script>
-</head>
-<body>
+		</script>
+	</head>
 
-<!--BEGIN FLYOUT FOR 'ZOOM TO LAYERS'-->
+	<body>
 
-<div id="mySidenav" class="sidenav">
-	<a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
-	<p>
-	<br><br><br>
-	</p>
+	<!--BEGIN FLYOUT FOR 'ZOOM TO LAYERS'-->
 
-	<p class="moreinfo">Use the drop-down menus below to zoom to a School District, House District, or Senate District of your choice. Choose  the top entry on any drop down to return to the full extent of the state.
+		<div id="mySidenav" class="sidenav">
+			<a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+			<p>
+				<br /><br /><br />
+			</p>
+			<p class="moreinfo">
+				Use the drop-down menus below to zoom to a School District, House District, or Senate District of your choice. Choose  the top entry on any drop down to return to the full extent of the state.
+				<br /><br />
 
-	<br><br>
+				<!--Drop down controls-->
 
-	<!--Drop down controls-->
+				<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value, 'NAME');"></select>
+				<br /><br />
+				<select id="house-districts-control" onchange="zoomToPolygon('state-house-districts', this.value, 'District');"></select>
+				<br /><br />
+				<select id="senate-districts-control" onchange="zoomToPolygon('state-senate-districts', this.value, 'District');"></select>
 
-	<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value, 'NAME');"></select>
-     <BR>
-	 <BR>
-	 <select id="house-districts-control" onchange="zoomToPolygon('state-house-districts', this.value, 'District');"></select>
-      <BR>
-	  <BR>
-	  <select id="senate-districts-control" onchange="zoomToPolygon('state-senate-districts', this.value, 'District');"></select>
-
-
-	<br><br>
-
-	Map produced by <a href="http://www.coregis.net/" target="_blank">CoreGIS</a>.
-
-	<br><br>
-
-	<a href="https://www.raiseyourhandtexas.org/" target="_blank">Raise Your Hand Texas</a>
-	<br>
-    <a href="https://www.raiseyourhandtexas.org/contact/" target="_blank">Contact</a>
-
-	</p>
-
-</div>
-
-<div id="main">
-
-<div id="about">
-  <span style="font-size:16px;cursor:pointer" onclick="openNav()">&#9776; Zoom to Districts</span>
-</div>
-
-<script>
-	function openNav() {
-		document.getElementById("mySidenav").style.width = "300px";
-		document.getElementById("main").style.marginLeft = "300px";
-	}
-
-	function closeNav() {
-		document.getElementById("mySidenav").style.width = "0";
-		document.getElementById("main").style.marginLeft= "0";
-	}
-</script>
-
-<!--END FLYOUT FOR 'ZOOM TO LAYERS'-->
-
-<div id='map'></div>
-
-<div class='legend'>
-	<div class='legend-title'>Click on a layer name below to toggle its visibility</div>
-		<div class='legend-scale'>
-			<ul class='legend-labels'>
-				<li onClick="showHideLayer('raising-blended-learners-points', markerName='raising_blended_learners');"><span id="raising_blended_learners" class="inactive"></span>Raising Blended Learners</li>
-				<li onClick="showHideLayer('raising-family-partnerships-points', markerName='raising_family_partnerships');"><span id="raising_family_partnerships" class="inactive"></span>Raising Family Partnerships</li>
-				<li onClick="showHideLayer('charles-butt-scholars-points', markerName='charles_butt_scholars');"><span id="charles_butt_scholars" class="inactive"></span>Charles Butt Scholars</li>
-				<li onClick="showHideLayer('raising-texas-teachers-points', markerName='raising_texas_teachers');"><span id="raising_texas_teachers" class="inactive"></span>Raising Texas Teachers</li>
-				<li onClick="showHideLayer('raising-school-leaders-points', markerName='raising_school_leaders');"><span id="raising_school_leaders" class="inactive"></span>Raising School Leaders</li>
-<!--
-				<li onClick="showHideLayer('districts-of-innovation-points', markerName='districts_of_innovation');"><span id="districts_of_innovation" class="inactive"></span>Districts of Innovation</li>
--->
-				<li onClick="showHideLayer('districts-of-innovation-poly-fill', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly" class="inactive"></span>Districts of Innovation</li>
-				<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
-				<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
-				<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
-			</ul>
+				<br /><br />
+				Map produced by <a href="http://www.coregis.net/" target="_blank">CoreGIS</a>.
+				<br /><br />
+				<a href="https://www.raiseyourhandtexas.org/" target="_blank">Raise Your Hand Texas</a>
+				<br />
+				<a href="https://www.raiseyourhandtexas.org/contact/" target="_blank">Contact</a>
+			</p>
 		</div>
-		<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/"  target="_blank">Raise Your Hand Texas</a></div>
-		<div class='map-credit'>Map design by <a href="http://www.coregis.net/"  target="_blank">CORE GIS</a></div>
-	</div>
-</div>
 
-<script>
-	mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
+		<div id="main">
 
-	//set bounds to Texas
-	var bounds = [
-			[-114.9594,21.637], // southwest coords
-			[-85.50,39.317] // northeast coords
-		];
+		<div id="about">
+			<span style="font-size:16px;cursor:pointer" onclick="openNav()">&#9776; Zoom to Districts</span>
+		</div>
 
-	var map = new mapboxgl.Map({
-			container: 'map', // container id
-			style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
-			center: [-98.887939,31.821565], // starting position [lng, lat]
-			zoom: 5.5, // starting zoom
-		maxBounds:  bounds // sets bounds as max
-
-	});
-
-	var originalZoomLevel = map.getZoom();
-
-	function setVisibilityState(params) {
-		if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
-			if ((params.legendID !== undefined) && (params.legendID !== false)) {
-				document.getElementById(params.legendID).classList.add('inactive');
+		<script>
+			function openNav() {
+				document.getElementById("mySidenav").style.width = "300px";
+				document.getElementById("main").style.marginLeft = "300px";
 			}
-			return 'none';
-		}	else {
-			if ((params.legendID !== undefined) && (params.legendID !== false)) {
-				document.getElementById(params.legendID).classList.remove('inactive');
-			}
-			return 'visible'
-		}
-	}
 
-	function addPointLayer(map, params) {
-		gus_api(params.gusID, function(jsondata) {
-			var visibilityState = setVisibilityState(params);
-			map.addSource(params.sourceName, {
-				type: 'geojson',
-				data: jsondata
+			function closeNav() {
+				document.getElementById("mySidenav").style.width = "0";
+				document.getElementById("main").style.marginLeft= "0";
+			}
+		</script>
+
+	<!--END FLYOUT FOR 'ZOOM TO LAYERS'-->
+
+		<div id='map'></div>
+
+		<div class='legend'>
+			<div class='legend-title'>Click on a layer name below to toggle its visibility</div>
+				<div class='legend-scale'>
+					<ul class='legend-labels'>
+						<li onClick="showHideLayer('raising-blended-learners-points', markerName='raising_blended_learners');"><span id="raising_blended_learners" class="inactive"></span>Raising Blended Learners</li>
+						<li onClick="showHideLayer('raising-family-partnerships-points', markerName='raising_family_partnerships');"><span id="raising_family_partnerships" class="inactive"></span>Raising Family Partnerships</li>
+						<li onClick="showHideLayer('charles-butt-scholars-points', markerName='charles_butt_scholars');"><span id="charles_butt_scholars" class="inactive"></span>Charles Butt Scholars</li>
+						<li onClick="showHideLayer('raising-texas-teachers-points', markerName='raising_texas_teachers');"><span id="raising_texas_teachers" class="inactive"></span>Raising Texas Teachers</li>
+						<li onClick="showHideLayer('raising-school-leaders-points', markerName='raising_school_leaders');"><span id="raising_school_leaders" class="inactive"></span>Raising School Leaders</li>
+		<!--
+						<li onClick="showHideLayer('districts-of-innovation-points', markerName='districts_of_innovation');"><span id="districts_of_innovation" class="inactive"></span>Districts of Innovation</li>
+		-->
+						<li onClick="showHideLayer('districts-of-innovation-poly-fill', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly" class="inactive"></span>Districts of Innovation</li>
+						<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
+						<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
+						<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
+					</ul>
+				</div>
+				<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/"  target="_blank">Raise Your Hand Texas</a></div>
+				<div class='map-credit'>Map design by <a href="http://www.coregis.net/"  target="_blank">CORE GIS</a></div>
+			</div>
+		</div>
+
+		<script>
+			mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
+
+			//set bounds to Texas
+			var bounds = [
+					[-114.9594,21.637], // southwest coords
+					[-85.50,39.317] // northeast coords
+				];
+
+			var map = new mapboxgl.Map({
+					container: 'map', // container id
+					style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
+					center: [-98.887939,31.821565], // starting position [lng, lat]
+					zoom: 5.5, // starting zoom
+				maxBounds:  bounds // sets bounds as max
+
 			});
-			map.addLayer({
-				'id': params.layerName,
-				'type': 'symbol',
-				'source': params.sourceName,
-				'layout': {
-					'icon-image': params.icon,
-					'icon-size': params.iconSize,
-					'icon-allow-overlap': true,
-					'visibility': visibilityState
+
+			var originalZoomLevel = map.getZoom();
+
+			function setVisibilityState(params) {
+				if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
+					if ((params.legendID !== undefined) && (params.legendID !== false)) {
+						document.getElementById(params.legendID).classList.add('inactive');
+					}
+					return 'none';
+				}	else {
+					if ((params.legendID !== undefined) && (params.legendID !== false)) {
+						document.getElementById(params.legendID).classList.remove('inactive');
+					}
+					return 'visible'
 				}
-			});
-			map.on("zoomend", function(){
-				map.setLayoutProperty(params.layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * params.iconSize);
-			});
-		});
-	}
+			}
 
-	function addVectorLayer(map, params) {
-		var visibilityState = setVisibilityState(params);
-		map.addSource(params.sourceName, {
-			type: 'vector',
-			url: params.sourceURL
-		});
-		if ((params.lineLayerName !== undefined) && (params.lineLayerName !== false)) {
-			map.addLayer(
-				{
-					'id': params.lineLayerName,
-					'type': 'line',
-					'source': params.sourceName,
-					'source-layer': params.sourceID,
-					'layout': {
-						'visibility': visibilityState,
-						'line-join': 'round',
-						'line-cap': 'round'
-					},
-					'paint': {
-						'line-color': params.lineColor,
-						'line-width': 1
-					},
-				},
-				params.displayBehind
-			);
-		}
-		if ((params.polygonLayerName !== undefined) && (params.polygonLayerName !== false)) {
-			map.addLayer(
-				{
-					'id': params.polygonLayerName,
-					'type': 'fill',
-					'source': params.sourceName,
-					'source-layer': params.sourceID,
-					'layout': {
-						'visibility': visibilityState
-					},
-					'paint': {
-						'fill-color': params.polygonFillColor,
-						'fill-outline-color': params.polygonOutlineColor
-					},
+			function addPointLayer(map, params) {
+				gus_api(params.gusID, function(jsondata) {
+					var visibilityState = setVisibilityState(params);
+					map.addSource(params.sourceName, {
+						type: 'geojson',
+						data: jsondata
+					});
+					map.addLayer({
+						'id': params.layerName,
+						'type': 'symbol',
+						'source': params.sourceName,
+						'layout': {
+							'icon-image': params.icon,
+							'icon-size': params.iconSize,
+							'icon-allow-overlap': true,
+							'visibility': visibilityState
+						}
+					});
+					map.on("zoomend", function(){
+						map.setLayoutProperty(params.layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * params.iconSize);
+					});
+				});
+			}
+
+			function addVectorLayer(map, params) {
+				var visibilityState = setVisibilityState(params);
+				map.addSource(params.sourceName, {
+					type: 'vector',
+					url: params.sourceURL
+				});
+				if ((params.lineLayerName !== undefined) && (params.lineLayerName !== false)) {
+					map.addLayer(
+						{
+							'id': params.lineLayerName,
+							'type': 'line',
+							'source': params.sourceName,
+							'source-layer': params.sourceID,
+							'layout': {
+								'visibility': visibilityState,
+								'line-join': 'round',
+								'line-cap': 'round'
+							},
+							'paint': {
+								'line-color': params.lineColor,
+								'line-width': 1
+							},
+						},
+						params.displayBehind
+					);
 				}
-			);
-		}
-	}
-
-
-
-	/*
-		How to add point layers using the GUS API:
-		Call the addPointLayer() function with arguments like the examples below.
-
-		How to add vector layers using Mapbox:
-		Call the addVectorLayer() function with arguments like the examples below.
-		Note that these calls have to be after the addPointLayer() ones, because they will reference at least one of the point layers as a way of making sure polygons get drawn behind points.
-	*/
-
-	map.on('load', function () {
-		addPointLayer(
-			map,
-			{
-				'gusID': "1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
-				'sourceName': 'raising-family-partnerships', // this one will be the data source name
-				'layerName': 'raising-family-partnerships-points', // layer name
-				'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
-				'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended initial display size, so that when it gets scaled up on zooming in it will still look good
-				'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
-				'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
+				if ((params.polygonLayerName !== undefined) && (params.polygonLayerName !== false)) {
+					map.addLayer(
+						{
+							'id': params.polygonLayerName,
+							'type': 'fill',
+							'source': params.sourceName,
+							'source-layer': params.sourceID,
+							'layout': {
+								'visibility': visibilityState
+							},
+							'paint': {
+								'fill-color': params.polygonFillColor,
+								'fill-outline-color': params.polygonOutlineColor
+							},
+						}
+					);
+				}
 			}
-		);
 
-		addPointLayer(
-			map,
-			{
-				'gusID': '1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE',
-				'sourceName': 'raising-blended-learners',
-				'layerName': 'raising-blended-learners-points',
-				'icon': 'raising_blended_learners_large',
-				'iconSize': 0.1,
-				'legendID': 'raising_blended_learners'
-			}
-		);
 
-		addPointLayer(
-			map,
-			{
-				'gusID': "1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
-				'sourceName': 'charles-butt-scholars',
-				'layerName': 'charles-butt-scholars-points',
-				'icon': 'charles_butt_scholars_large',
-				'iconSize': 0.1,
-				'legendID': 'charles_butt_scholars'
-			}
-		);
 
-		addPointLayer(
-			map,
-			{
-				'gusID': "1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
-				'sourceName': 'raising-texas-teachers',
-				'layerName': 'raising-texas-teachers-points',
-				'icon': 'raising_texas_teachers_large',
-				'iconSize': 0.1,
-				'legendID': 'raising_texas_teachers'
-			}
-		);
-
-		addPointLayer(
-			map,
-			{
-				'gusID': "1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
-				'sourceName': 'raising-school-leaders',
-				'layerName': 'raising-school-leaders-points',
-				'icon': 'raising_school_leaders_large',
-				'iconSize': 0.1,
-				'legendID': 'raising_school_leaders'
-			}
-		);
 /*
-		addPointLayer(
-			map,
-			{
-				'gusID': "1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
-				'sourceName': 'districts-of-innovation',
-				'layerName': 'districts-of-innovation-points',
-				'icon': 'districts_of_innovation_large',
-				'iconSize': 0.1,
-				'legendID': 'districts_of_innovation'
-			}
-		);
+	How to add point layers using the GUS API:
+	Call the addPointLayer() function with arguments like the examples below.
+
+	How to add vector layers using Mapbox:
+	Call the addVectorLayer() function with arguments like the examples below.
+	Note that these calls have to be after the addPointLayer() ones, because they will reference at least one of the point layers as a way of making sure polygons get drawn behind points.
 */
 
-		addVectorLayer(
-			map,
-			{
-				'sourceName': 'texas-school-districts', // data source name for internal use
-				'sourceID': 'texas_school_districts_v2', // name of the Mapbox layer from which the data will be loaded
-				'sourceURL': 'mapbox://core-gis.e4af0de1', // Mapbox URL
-				'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines.  Leave out or set to false if you don't want outlines displayed.
-				'lineColor': '#a1b082', // colour to draw those outlines with; safe to leave out if we're not drawing outlines, but must be explicitly set if we are
-				'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
-				'displayBehind': 'raising-school-leaders-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
-				'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.  Leave out or set to false if you don't want one.
-				'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
-				'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
-				'visibleOnLoad': false // set this optional argument to true to have the layer visible on load.  Leave out or set to false to have it hidden on load
+			map.on('load', function () {
+				addPointLayer(
+					map,
+					{
+						'gusID': "1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
+						'sourceName': 'raising-family-partnerships', // this one will be the data source name
+						'layerName': 'raising-family-partnerships-points', // layer name
+						'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
+						'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended initial display size, so that when it gets scaled up on zooming in it will still look good
+						'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
+						'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': '1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE',
+						'sourceName': 'raising-blended-learners',
+						'layerName': 'raising-blended-learners-points',
+						'icon': 'raising_blended_learners_large',
+						'iconSize': 0.1,
+						'legendID': 'raising_blended_learners'
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': "1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
+						'sourceName': 'charles-butt-scholars',
+						'layerName': 'charles-butt-scholars-points',
+						'icon': 'charles_butt_scholars_large',
+						'iconSize': 0.1,
+						'legendID': 'charles_butt_scholars'
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': "1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
+						'sourceName': 'raising-texas-teachers',
+						'layerName': 'raising-texas-teachers-points',
+						'icon': 'raising_texas_teachers_large',
+						'iconSize': 0.1,
+						'legendID': 'raising_texas_teachers'
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': "1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
+						'sourceName': 'raising-school-leaders',
+						'layerName': 'raising-school-leaders-points',
+						'icon': 'raising_school_leaders_large',
+						'iconSize': 0.1,
+						'legendID': 'raising_school_leaders'
+					}
+				);
+		/*
+				addPointLayer(
+					map,
+					{
+						'gusID': "1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
+						'sourceName': 'districts-of-innovation',
+						'layerName': 'districts-of-innovation-points',
+						'icon': 'districts_of_innovation_large',
+						'iconSize': 0.1,
+						'legendID': 'districts_of_innovation'
+					}
+				);
+		*/
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'texas-school-districts', // data source name for internal use
+						'sourceID': 'texas_school_districts_v2', // name of the Mapbox layer from which the data will be loaded
+						'sourceURL': 'mapbox://core-gis.e4af0de1', // Mapbox URL
+						'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines.  Leave out or set to false if you don't want outlines displayed.
+						'lineColor': '#a1b082', // colour to draw those outlines with; safe to leave out if we're not drawing outlines, but must be explicitly set if we are
+						'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
+						'displayBehind': 'raising-school-leaders-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
+						'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.  Leave out or set to false if you don't want one.
+						'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
+						'visibleOnLoad': false // set this optional argument to true to have the layer visible on load.  Leave out or set to false to have it hidden on load
+					}
+				);
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'state-senate-districts',
+						'sourceID': 'state_senate_districts-0g2odu',
+						'sourceURL': 'mapbox://core-gis.b2eu90mx',
+						'lineLayerName': 'state-senate-districts-lines',
+						'lineColor': '#a1b082',
+						'legendID': 'state_senate_districts',
+						'displayBehind': 'raising-school-leaders-points',
+						'polygonLayerName': 'state-senate-districts-poly',
+						'polygonFillColor': 'rgba(200, 100, 240, 0)',
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+					}
+				);
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'state-house-districts',
+						'sourceID': 'state_house_districts-1vl4x8',
+						'sourceURL': 'mapbox://core-gis.9drnaiu0',
+						'lineLayerName': 'state-house-districts-lines',
+						'lineColor': 'rgba(117, 137, 77, 0.5)',
+						'legendID': 'state_house_districts',
+						'displayBehind': 'raising-school-leaders-points',
+						'polygonLayerName': 'state-house-districts-poly',
+						'polygonFillColor': 'rgba(200, 100, 240, 0)',
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+					}
+				);
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'districts-of-innovation-poly',
+						'sourceID': 'districts_of_innovation_poly_v1',
+						'sourceURL': 'mapbox://core-gis.97b01c24',
+						'legendID': 'districts_of_innovation_poly',
+						'displayBehind': 'texas-school-districts-lines',
+						'polygonLayerName': 'districts-of-innovation-poly-fill',
+						'polygonFillColor': 'rgba(247, 247, 198, 100)',
+						'polygonOutlineColor': 'rgba(194, 194, 126, 100)'
+					}
+				);
+
+				// This one's a special case: it's never displayed, but it's used to set what will appear in popups when someone clicks on the map
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'school_house_senate_districts_UNION',
+						'sourceID': 'school_house_senate_districts_UNION',
+						'sourceURL': 'mapbox://core-gis.a81c8ecf',
+						'displayBehind': 'districts-of-innovation-points',
+						'polygonLayerName': 'school_house_senate_districts_UNION-poly',
+						'polygonFillColor': 'rgba(200, 100, 240, 0)',
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+					}
+				);
+
+				runWhenLoadComplete();
+
+			});
+
+		// This is the popup for the merged boundary layers
+		// When a click event occurs on a feature in the unioned districts layer, open a popup at the
+		// location of the click, with description HTML from its properties.
+			map.on('click', 'school_house_senate_districts_UNION-poly', function (e) {
+				new mapboxgl.Popup()
+					.setLngLat(e.lngLat)
+					.setHTML(fillpopup(e.features[0].properties))
+					.addTo(map);
+			});
+
+			 // Change the cursor to a pointer when the mouse is over the house districts layer.
+				map.on('mouseenter', 'school_house_senate_districts_UNION-poly', function () {
+					map.getCanvas().style.cursor = 'pointer';
+				});
+
+				// Change it back to a pointer when it leaves.
+				map.on('mouseleave', 'school_house_senate_districts_UNION-poly', function () {
+					map.getCanvas().style.cursor = '';
+				});
+
+			function fillpopup(data){
+				var html = "";
+				html = html + "<span class='varname'>School District: </span> <span class='attribute'>" + data.SchDistNam + "</span>";
+				html = html + "<br />"
+				html = html + "<span class='varname'>House District: </span> <span class='attribute'>" + data.HseDistNum + "</span>";
+				html = html + "<br />"
+				html = html + "<span class='varname'>Senate District: </span> <span class='attribute'>" + data.SenDistNum + "</span>";
+				return html;
+				//this will return the string to the calling function
+
 			}
-		);
 
-		addVectorLayer(
-			map,
-			{
-				'sourceName': 'state-senate-districts',
-				'sourceID': 'state_senate_districts-0g2odu',
-				'sourceURL': 'mapbox://core-gis.b2eu90mx',
-				'lineLayerName': 'state-senate-districts-lines',
-				'lineColor': '#a1b082',
-				'legendID': 'state_senate_districts',
-				'displayBehind': 'raising-school-leaders-points',
-				'polygonLayerName': 'state-senate-districts-poly',
-				'polygonFillColor': 'rgba(200, 100, 240, 0)',
-				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+
+
+			function fetchJSONFile(path, callback) {
+				var httpRequest = new XMLHttpRequest();
+				httpRequest.onreadystatechange = function() {
+					if (httpRequest.readyState === 4) {
+						if (httpRequest.status === 200) {
+							var data = JSON.parse(httpRequest.responseText);
+							if (callback) callback(data);
+						}
+					}
+				};
+				httpRequest.open('GET', path);
+				httpRequest.send();
 			}
-		);
 
-		addVectorLayer(
-			map,
-			{
-				'sourceName': 'state-house-districts',
-				'sourceID': 'state_house_districts-1vl4x8',
-				'sourceURL': 'mapbox://core-gis.9drnaiu0',
-				'lineLayerName': 'state-house-districts-lines',
-				'lineColor': 'rgba(117, 137, 77, 0.5)',
-				'legendID': 'state_house_districts',
-				'displayBehind': 'raising-school-leaders-points',
-				'polygonLayerName': 'state-house-districts-poly',
-				'polygonFillColor': 'rgba(200, 100, 240, 0)',
-				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
-			}
-		);
+			function gus_api(id, callback) {
+				const url = `https://spreadsheets.google.com/feeds/cells/${id}/od6/public/basic?alt=json`;
 
-		addVectorLayer(
-			map,
-			{
-				'sourceName': 'districts-of-innovation-poly',
-				'sourceID': 'districts_of_innovation_poly_v1',
-				'sourceURL': 'mapbox://core-gis.97b01c24',
-				'legendID': 'districts_of_innovation_poly',
-				'displayBehind': 'texas-school-districts-lines',
-				'polygonLayerName': 'districts-of-innovation-poly-fill',
-				'polygonFillColor': 'rgba(247, 247, 198, 100)',
-				'polygonOutlineColor': 'rgba(194, 194, 126, 100)'
-			}
-		);
+				fetchJSONFile(url, function(data) {
 
-		// This one's a special case: it's never displayed, but it's used to set what will appear in popups when someone clicks on the map
-		addVectorLayer(
-			map,
-			{
-				'sourceName': 'school_house_senate_districts_UNION',
-				'sourceID': 'school_house_senate_districts_UNION',
-				'sourceURL': 'mapbox://core-gis.a81c8ecf',
-				'displayBehind': 'districts-of-innovation-points',
-				'polygonLayerName': 'school_house_senate_districts_UNION-poly',
-				'polygonFillColor': 'rgba(200, 100, 240, 0)',
-				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
-			}
-		);
+					let headers = {};
+					let entries = {};
 
-		runWhenLoadComplete();
+					data.feed.entry.forEach((e) => {
+						// get the row number
+						const row = parseInt(e.title['$t'].match(/\d+/g)[0]);
+						const column = e.title['$t'].match(/[a-zA-Z]+/g)[0];
+						const content = e.content['$t'];
 
-	});
+						// it's a header
+						if (row === 1) {
+							headers[column] = content;
+						} else {
+							if (!entries[row]) entries[row] = {};
+							entries[row][headers[column]] = content;
+						}
+					});
 
-// This is the popup for the merged boundary layers
-// When a click event occurs on a feature in the unioned districts layer, open a popup at the
-// location of the click, with description HTML from its properties.
-	map.on('click', 'school_house_senate_districts_UNION-poly', function (e) {
-		new mapboxgl.Popup()
-			.setLngLat(e.lngLat)
-			.setHTML(fillpopup(e.features[0].properties))
-			.addTo(map);
-	});
+					const gj = { type: 'FeatureCollection', features: [] };
+					for (let e in entries) {
 
-	 // Change the cursor to a pointer when the mouse is over the house districts layer.
-    map.on('mouseenter', 'school_house_senate_districts_UNION-poly', function () {
-			map.getCanvas().style.cursor = 'pointer';
-    });
+						const feature = {
+							type: 'Feature',
+							geometry: {
+								type: 'Point',
+								coordinates: [0, 0]
+							},
+							properties: entries[e]
+						};
 
-    // Change it back to a pointer when it leaves.
-    map.on('mouseleave', 'school_house_senate_districts_UNION-poly', function () {
-			map.getCanvas().style.cursor = '';
-    });
+						for (let p in entries[e]) {
+							switch(p) {
+								case 'longitude':
+								case 'LONGITUDE':
+								case 'long':
+								case 'LONG':
+								case 'lng':
+								case 'LNG':
+								case 'lon':
+								case 'LON':
+								case 'x':
+								case 'X':
+									feature.geometry.coordinates[0] = parseFloat(entries[e][p]);
+								case 'latitude':
+								case 'LATITUDE':
+								case 'lat':
+								case 'LAT':
+								case 'y':
+								case 'Y':
+									feature.geometry.coordinates[1] = parseFloat(entries[e][p]);
+							}
+						}
 
-	function fillpopup(data){
-		var html = "";
-		html = html + "<span class='varname'>School District: </span> <span class='attribute'>" + data.SchDistNam + "</span>";
-		html = html + "<br>"
-		html = html + "<span class='varname'>House District: </span> <span class='attribute'>" + data.HseDistNum + "</span>";
-		html = html + "<br>"
-		html = html + "<span class='varname'>Senate District: </span> <span class='attribute'>" + data.SenDistNum + "</span>";
-		return html;
-		//this will return the string to the calling function
+						gj.features.push(feature);
+					}
 
-	}
+					callback(gj);
+				});
+			};
+		</script>
 
-
-
-
-
-
-function fetchJSONFile(path, callback) {
-	var httpRequest = new XMLHttpRequest();
-	httpRequest.onreadystatechange = function() {
-		if (httpRequest.readyState === 4) {
-			if (httpRequest.status === 200) {
-				var data = JSON.parse(httpRequest.responseText);
-				if (callback) callback(data);
-			}
-		}
-	};
-	httpRequest.open('GET', path);
-	httpRequest.send();
-}
-
-function gus_api(id, callback) {
-  const url = `https://spreadsheets.google.com/feeds/cells/${id}/od6/public/basic?alt=json`;
-
-  fetchJSONFile(url, function(data) {
-
-    let headers = {};
-    let entries = {};
-
-    data.feed.entry.forEach((e) => {
-      // get the row number
-      const row = parseInt(e.title['$t'].match(/\d+/g)[0]);
-      const column = e.title['$t'].match(/[a-zA-Z]+/g)[0];
-      const content = e.content['$t'];
-
-      // it's a header
-      if (row === 1) {
-        headers[column] = content;
-      } else {
-        if (!entries[row]) entries[row] = {};
-        entries[row][headers[column]] = content;
-      }
-    });
-
-    const gj = { type: 'FeatureCollection', features: [] };
-    for (let e in entries) {
-
-      const feature = {
-        type: 'Feature',
-        geometry: {
-          type: 'Point',
-          coordinates: [0, 0]
-        },
-        properties: entries[e]
-      };
-
-      for (let p in entries[e]) {
-        switch(p) {
-          case 'longitude':
-          case 'LONGITUDE':
-          case 'long':
-          case 'LONG':
-          case 'lng':
-          case 'LNG':
-          case 'lon':
-          case 'LON':
-          case 'x':
-          case 'X':
-            feature.geometry.coordinates[0] = parseFloat(entries[e][p]);
-          case 'latitude':
-          case 'LATITUDE':
-          case 'lat':
-          case 'LAT':
-          case 'y':
-          case 'Y':
-            feature.geometry.coordinates[1] = parseFloat(entries[e][p]);
-        }
-      }
-
-      gj.features.push(feature);
-    }
-
-    callback(gj);
-  });
-};
-</script>
-
-</body>
+	</body>
 </html>

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -486,23 +486,18 @@
 			}
 		);
 
-		map.addSource('school_house_senate_districts_UNION', {
-			type: 'vector',
-			url: 'mapbox://core-gis.a81c8ecf'
-		});
-		map.addLayer(
+		// This one's a special case: it's never displayed, but it's used to set what will appear in popups when someone clicks on the map
+		addVectorLayer(
+			map,
 			{
-				'id': 'school_house_senate_districts_UNION-poly',
-				'type': 'fill',
-				'source': 'school_house_senate_districts_UNION',
-				'source-layer': 'school_house_senate_districts_UNION',
-				'paint': {
-					'fill-color': 'rgba(200, 100, 240, 0)',
-					'fill-outline-color': 'rgba(200, 100, 240, 0)'
-				},
-			},
-			'districts-of-innovation-points'
+				'sourceName': 'school_house_senate_districts_UNION',
+				'sourceID': 'school_house_senate_districts_UNION',
+				'sourceURL': 'mapbox://core-gis.a81c8ecf',
+				'displayBehind': 'districts-of-innovation-points',
+				'polygonLayerName': 'school_house_senate_districts_UNION-poly'
+			}
 		);
+
 		runWhenLoadComplete();
 
 	});

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -197,10 +197,10 @@
 				<li onClick="showHideLayer('charles-butt-scholars-points', markerName='charles_butt_scholars');"><span id="charles_butt_scholars" class="inactive"></span>Charles Butt Scholars</li>
 				<li onClick="showHideLayer('raising-texas-teachers-points', markerName='raising_texas_teachers');"><span id="raising_texas_teachers" class="inactive"></span>Raising Texas Teachers</li>
 				<li onClick="showHideLayer('raising-school-leaders-points', markerName='raising_school_leaders');"><span id="raising_school_leaders" class="inactive"></span>Raising School Leaders</li>
+<!--
 				<li onClick="showHideLayer('districts-of-innovation-points', markerName='districts_of_innovation');"><span id="districts_of_innovation" class="inactive"></span>Districts of Innovation</li>
-				<!--
-				<li onClick="showHideLayer('districts-of-innovation-poly-lines', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly"></span>Districts of Innovation Poly</li>
-				-->
+-->
+				<li onClick="showHideLayer('districts-of-innovation-poly-fill', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly" class="inactive"></span>Districts of Innovation</li>
 				<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
 				<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
 				<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
@@ -302,6 +302,9 @@
 					'type': 'fill',
 					'source': params.sourceName,
 					'source-layer': params.sourceID,
+					'layout': {
+						'visibility': visibilityState
+					},
 					'paint': {
 						'fill-color': params.polygonFillColor,
 						'fill-outline-color': params.polygonOutlineColor
@@ -383,7 +386,7 @@
 				'legendID': 'raising_school_leaders'
 			}
 		);
-
+/*
 		addPointLayer(
 			map,
 			{
@@ -395,52 +398,7 @@
 				'legendID': 'districts_of_innovation'
 			}
 		);
-
-
-		/*
-		//Attempting to add in the Districts of Innovation as polygons
-		map.addSource('districts-of-innovation-poly', {
-			type: 'vector',
-			url: 'mapbox://core-gis.97b01c24'
-		});
-		map.addLayer(
-			{
-				'id': 'districts-of-innovation-poly-lines',
-				'type': 'line',
-				'source': 'districts-of-innovation-poly',
-				'source-layer': 'districts_of_innovation_poly_v1',
-				'layout': {
-					'visibility': 'visible',
-					'line-join': 'round',
-					'line-cap': 'round'
-				},
-				'paint': {
-					'line-color': '#f7f7c6',
-					'line-width': 1
-				},
-			},
-			'districts-of-innovation-points'
-		);
-		map.addLayer(
-			{
-				'id': 'districts-of-innovation-poly-fill',
-				'type': 'fill',
-				'source': 'districts-of-innovation-poly',
-				'source-layer': 'districts_of_innovation_poly_v1',
-				'layout': {
-
-
-				},
-				'paint': {
-					'fill-color': 'rgba(247, 247, 198, 100)',
-					'fill-outline-color': 'rgba(194, 194, 126, 100)'
-				},
-			}
-		);
-
-		//End Districts of Innovation as poly
-		*/
-
+*/
 
 		addVectorLayer(
 			map,
@@ -451,7 +409,7 @@
 				'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines.  Leave out or set to false if you don't want outlines displayed.
 				'lineColor': '#a1b082', // colour to draw those outlines with; safe to leave out if we're not drawing outlines, but must be explicitly set if we are
 				'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
-				'displayBehind': 'districts-of-innovation-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
+				'displayBehind': 'raising-school-leaders-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
 				'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.  Leave out or set to false if you don't want one.
 				'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
 				'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
@@ -468,7 +426,7 @@
 				'lineLayerName': 'state-senate-districts-lines',
 				'lineColor': '#a1b082',
 				'legendID': 'state_senate_districts',
-				'displayBehind': 'districts-of-innovation-points',
+				'displayBehind': 'raising-school-leaders-points',
 				'polygonLayerName': 'state-senate-districts-poly',
 				'polygonFillColor': 'rgba(200, 100, 240, 0)',
 				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
@@ -484,10 +442,24 @@
 				'lineLayerName': 'state-house-districts-lines',
 				'lineColor': 'rgba(117, 137, 77, 0.5)',
 				'legendID': 'state_house_districts',
-				'displayBehind': 'districts-of-innovation-points',
+				'displayBehind': 'raising-school-leaders-points',
 				'polygonLayerName': 'state-house-districts-poly',
 				'polygonFillColor': 'rgba(200, 100, 240, 0)',
 				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+			}
+		);
+
+		addVectorLayer(
+			map,
+			{
+				'sourceName': 'districts-of-innovation-poly',
+				'sourceID': 'districts_of_innovation_poly_v1',
+				'sourceURL': 'mapbox://core-gis.97b01c24',
+				'legendID': 'districts_of_innovation_poly',
+				'displayBehind': 'texas-school-districts-lines',
+				'polygonLayerName': 'districts-of-innovation-poly-fill',
+				'polygonFillColor': 'rgba(247, 247, 198, 100)',
+				'polygonOutlineColor': 'rgba(194, 194, 126, 100)'
 			}
 		);
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -407,9 +407,6 @@
 				'type': 'fill',
 				'source': 'texas-school-districts',
 				'source-layer': 'texas_school_districts_v2',
-				'layout': {
-
-				},
 				'paint': {
 					'fill-color': 'rgba(200, 100, 240, 0)',
 					'fill-outline-color': 'rgba(200, 100, 240, 0)'
@@ -445,9 +442,6 @@
 				'type': 'fill',
 				'source': 'state-senate-districts',
 				'source-layer': 'state_senate_districts-0g2odu',
-				'layout': {
-
-				},
 				'paint': {
 					'fill-color': 'rgba(200, 100, 240, 0)',
 					'fill-outline-color': 'rgba(200, 100, 240, 0)'
@@ -465,9 +459,6 @@
 				'type': 'fill',
 				'source': 'school_house_senate_districts_UNION',
 				'source-layer': 'school_house_senate_districts_UNION',
-				'layout': {
-
-				},
 				'paint': {
 					'fill-color': 'rgba(200, 100, 240, 0)',
 					'fill-outline-color': 'rgba(200, 100, 240, 0)'
@@ -505,9 +496,6 @@
 				'type': 'fill',
 				'source': 'state-house-districts',
 				'source-layer': 'state_house_districts-1vl4x8',
-				'layout': {
-
-				},
 				'paint': {
 					'fill-color': 'rgba(200, 100, 240, 0)',
 					'fill-outline-color': 'rgba(200, 100, 240, 0)'

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -263,6 +263,52 @@
 		});
 	}
 
+	function addVectorLayer(map, sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendid, displayBehind, polygonLayerName, visibleOnLoad) {
+		if ((visibleOnLoad === undefined) || (visibleOnLoad === false)) {
+			var visibilityState = 'none';
+			document.getElementById(legendid).classList.add('inactive');
+		}	else {
+			var visibilityState = 'visible';
+			document.getElementById(legendid).classList.remove('inactive');
+		}
+		map.addSource(sourceName, {
+			type: 'vector',
+			url: sourceURL
+		});
+		if ((lineLayerName !== undefined) && (lineLayerName !== false)) {
+			map.addLayer({
+				'id': lineLayerName,
+				'type': 'line',
+				'source': sourceName,
+				'source-layer': sourceID,
+				'layout': {
+					'visibility': visibilityState,
+					'line-join': 'round',
+					'line-cap': 'round'
+				},
+				'paint': {
+					'line-color': lineColor,
+					'line-width': 1
+				},
+				displayBehind
+			});
+		}
+		if ((polygonLayerName !== undefined) && (polygonLayerName !== false)) {
+			map.addLayer(
+				{
+					'id': polygonLayerName,
+					'type': 'fill',
+					'source': sourceName,
+					'source-layer': sourceID,
+					'paint': {
+						'fill-color': 'rgba(200, 100, 240, 0)',
+						'fill-outline-color': 'rgba(200, 100, 240, 0)'
+					},
+				}
+			);
+		}
+	}
+
 
 
 	/*
@@ -375,44 +421,20 @@
 
 		//End Districts of Innovation as poly
 		*/
-
-
-
-
-		map.addSource('texas-school-districts', {
-			type: 'vector',
-			url: 'mapbox://core-gis.e4af0de1'
-		});
-		map.addLayer(
-			{
-				'id': 'texas-school-districts-lines',
-				'type': 'line',
-				'source': 'texas-school-districts',
-				'source-layer': 'texas_school_districts_v2',
-				'layout': {
-					'visibility': 'none',
-					'line-join': 'round',
-					'line-cap': 'round'
-				},
-				'paint': {
-					'line-color': '#a1b082',
-					'line-width': 1
-				},
-			},
-			'districts-of-innovation-points'
+// map, sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendid, displayBehind, polygonLayerName, visibleOnLoad
+		addVectorLayer(
+			map,
+			'texas-school-districts',
+			'texas_school_districts_v2',
+			'mapbox://core-gis.e4af0de1',
+			'texas-school-districts-lines',
+			'#a1b082',
+			'texas_school_districts',
+			'districts-of-innovation-points',
+			'texas-school-districts-poly',
+			false
 		);
-		map.addLayer(
-			{
-				'id': 'texas-school-districts-poly',
-				'type': 'fill',
-				'source': 'texas-school-districts',
-				'source-layer': 'texas_school_districts_v2',
-				'paint': {
-					'fill-color': 'rgba(200, 100, 240, 0)',
-					'fill-outline-color': 'rgba(200, 100, 240, 0)'
-				},
-			}
-		);
+
 
 		map.addSource('state-senate-districts', {
 			type: 'vector',

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -231,17 +231,24 @@
 
 	var originalZoomLevel = map.getZoom();
 
+	function setVisibilityState(params) {
+		if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
+			if ((params.legendID !== undefined) && (params.legendID !== false)) {
+				document.getElementById(params.legendID).classList.add('inactive');
+			}
+			return 'none';
+		}	else {
+			if ((params.legendID !== undefined) && (params.legendID !== false)) {
+				document.getElementById(params.legendID).classList.remove('inactive');
+			}
+			return 'visible'
+		}
+	}
 
 // params: gusID, sourceName, layerName, icon, iconSize, legendID, visibleOnLoad
 	function addPointLayer(map, params) {
 		gus_api(params.gusID, function(jsondata) {
-			if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
-				var visibilityState = 'none';
-				document.getElementById(params.legendID).classList.add('inactive');
-			}	else {
-				var visibilityState = 'visible';
-				document.getElementById(params.legendID).classList.remove('inactive');
-			}
+			var visibilityState = setVisibilityState(params);
 			map.addSource(params.sourceName, {
 				type: 'geojson',
 				data: jsondata
@@ -265,18 +272,7 @@
 
 // params: sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendID, displayBehind, polygonLayerName, visibleOnLoad
 	function addVectorLayer(map, params) {
-		console.log(params);
-		if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
-			var visibilityState = 'none';
-			if ((params.legendID !== undefined) && (params.legendID !== false)) {
-				document.getElementById(params.legendID).classList.add('inactive');
-			}
-		}	else {
-			var visibilityState = 'visible';
-			if ((params.legendID !== undefined) && (params.legendID !== false)) {
-				document.getElementById(params.legendID).classList.remove('inactive');
-			}
-		}
+		var visibilityState = setVisibilityState(params);
 		map.addSource(params.sourceName, {
 			type: 'vector',
 			url: params.sourceURL

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -263,43 +263,47 @@
 		});
 	}
 
-	function addVectorLayer(map, sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendid, displayBehind, polygonLayerName, visibleOnLoad) {
-		if ((visibleOnLoad === undefined) || (visibleOnLoad === false)) {
+// map, sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendid, displayBehind, polygonLayerName, visibleOnLoad
+	function addVectorLayer(params) {
+		console.log(params);
+		if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
 			var visibilityState = 'none';
-			document.getElementById(legendid).classList.add('inactive');
+			document.getElementById(params.legendid).classList.add('inactive');
 		}	else {
 			var visibilityState = 'visible';
-			document.getElementById(legendid).classList.remove('inactive');
+			document.getElementById(params.legendid).classList.remove('inactive');
 		}
-		map.addSource(sourceName, {
+		map.addSource(params.sourceName, {
 			type: 'vector',
-			url: sourceURL
+			url: params.sourceURL
 		});
-		if ((lineLayerName !== undefined) && (lineLayerName !== false)) {
-			map.addLayer({
-				'id': lineLayerName,
-				'type': 'line',
-				'source': sourceName,
-				'source-layer': sourceID,
-				'layout': {
-					'visibility': visibilityState,
-					'line-join': 'round',
-					'line-cap': 'round'
-				},
-				'paint': {
-					'line-color': lineColor,
-					'line-width': 1
-				},
-				displayBehind
-			});
-		}
-		if ((polygonLayerName !== undefined) && (polygonLayerName !== false)) {
+		if ((params.lineLayerName !== undefined) && (params.lineLayerName !== false)) {
 			map.addLayer(
 				{
-					'id': polygonLayerName,
+					'id': params.lineLayerName,
+					'type': 'line',
+					'source': params.sourceName,
+					'source-layer': params.sourceID,
+					'layout': {
+						'visibility': visibilityState,
+						'line-join': 'round',
+						'line-cap': 'round'
+					},
+					'paint': {
+						'line-color': params.lineColor,
+						'line-width': 1
+					},
+				},
+				params.displayBehind
+			);
+		}
+		if ((params.polygonLayerName !== undefined) && (params.polygonLayerName !== false)) {
+			map.addLayer(
+				{
+					'id': params.polygonLayerName,
 					'type': 'fill',
-					'source': sourceName,
-					'source-layer': sourceID,
+					'source': params.sourceName,
+					'source-layer': params.sourceID,
 					'paint': {
 						'fill-color': 'rgba(200, 100, 240, 0)',
 						'fill-outline-color': 'rgba(200, 100, 240, 0)'
@@ -421,19 +425,20 @@
 
 		//End Districts of Innovation as poly
 		*/
-// map, sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendid, displayBehind, polygonLayerName, visibleOnLoad
-		addVectorLayer(
-			map,
-			'texas-school-districts',
-			'texas_school_districts_v2',
-			'mapbox://core-gis.e4af0de1',
-			'texas-school-districts-lines',
-			'#a1b082',
-			'texas_school_districts',
-			'districts-of-innovation-points',
-			'texas-school-districts-poly',
-			false
-		);
+
+
+		addVectorLayer({
+			'map': map,
+			'sourceName': 'texas-school-districts',
+			'sourceID': 'texas_school_districts_v2',
+			'sourceURL': 'mapbox://core-gis.e4af0de1',
+			'lineLayerName': 'texas-school-districts-lines',
+			'lineColor': '#a1b082',
+			'legendid': 'texas_school_districts',
+			'displayBehind': 'districts-of-innovation-points',
+			'polygonLayerName': 'texas-school-districts-poly',
+			'visibleOnLoad': false
+		});
 
 
 		map.addSource('state-senate-districts', {

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -233,7 +233,7 @@ var originalZoomLevel = map.getZoom();
 
 
 
-function addPointLayer(map, gusID, sourceName, layerName, icon, legendid, visibleOnLoad) {
+function addPointLayer(map, gusID, sourceName, layerName, icon, iconSize, legendid, visibleOnLoad) {
 	gus_api(gusID, function(jsondata) {
 		if ((visibleOnLoad === undefined) || (visibleOnLoad === false)) {
 			var visibilityState = 'none';
@@ -252,13 +252,13 @@ function addPointLayer(map, gusID, sourceName, layerName, icon, legendid, visibl
 			'source': sourceName,
 			layout: {
 				'icon-image': icon,
-				'icon-size':0.1,//initial size is small, so as we zoom the icon is returning towards native resolution
+				'icon-size': iconSize,
 				'icon-allow-overlap': true,
 				'visibility': visibilityState
 			}
 		});
 		map.on("zoomend", function(){
-			map.setLayoutProperty(layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5)*0.1);//the rightmost number in the parentheses should be the same as the 'icon-size' value in line 261; the 2.5 value is a best guess estimate to generate the zoom behavior we want
+			map.setLayoutProperty(layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * iconSize);
 		});
 	});
 }
@@ -274,7 +274,8 @@ map.on('load', function () {
 		"1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
 		'raising-family-partnerships', // this one will be the data source name
 		'raising-family-partnerships-points', // layer name
-		'raising_family_partnerships_large' ,// this one will be the icon image name, using the name from Mapbox
+		'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
+		0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
 		'raising_family_partnerships' // this one will be the id in the legend
 	);
 
@@ -284,6 +285,7 @@ map.on('load', function () {
 		'raising-blended-learners',
 		'raising-blended-learners-points',
 		'raising_blended_learners_large',
+		0.1,
 		'raising_blended_learners'
 	);
 
@@ -293,6 +295,7 @@ map.on('load', function () {
 		'charles-butt-scholars',
 		'charles-butt-scholars-points',
 		'charles_butt_scholars_large',
+		0.1,
 		'charles_butt_scholars',
 		true // set the optional final argument to true to have the layer visible on load
 	);
@@ -303,6 +306,7 @@ map.on('load', function () {
 		'raising-texas-teachers',
 		'raising-texas-teachers-points',
 		'raising_texas_teachers_large',
+		0.1,
 		'raising_texas_teachers'
 	);
 
@@ -312,6 +316,7 @@ map.on('load', function () {
 		'raising-school-leaders',
 		'raising-school-leaders-points',
 		'raising_school_leaders_large',
+		0.1,
 		'raising_school_leaders'
 	);
 
@@ -321,6 +326,7 @@ map.on('load', function () {
 		'districts-of-innovation',
 		'districts-of-innovation-points',
 		'districts_of_innovation_large',
+		0.1,
 		'districts_of_innovation'
 	);
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -458,39 +458,31 @@
 			}
 		);
 
-
-		map.addSource('state-senate-districts', {
-			type: 'vector',
-			url: 'mapbox://core-gis.b2eu90mx'
-		});
-		map.addLayer(
+		addVectorLayer(
+			map,
 			{
-				'id': 'state-senate-districts-lines',
-				'type': 'line',
-				'source': 'state-senate-districts',
-				'source-layer': 'state_senate_districts-0g2odu',
-				'layout': {
-					'visibility': 'none',
-					'line-join': 'round',
-					'line-cap': 'round'
-				},
-				'paint': {
-					'line-color': '#a1b082',
-					'line-width': 1
-				},
-			},
-			'districts-of-innovation-points'
+				'sourceName': 'state-senate-districts',
+				'sourceID': 'state_senate_districts-0g2odu',
+				'sourceURL': 'mapbox://core-gis.b2eu90mx',
+				'lineLayerName': 'state-senate-districts-lines',
+				'lineColor': '#a1b082',
+				'legendID': 'state_senate_districts',
+				'displayBehind': 'districts-of-innovation-points',
+				'polygonLayerName': 'state-senate-districts-poly'
+			}
 		);
-		map.addLayer(
+
+		addVectorLayer(
+			map,
 			{
-				'id': 'state-senate-districts-poly',
-				'type': 'fill',
-				'source': 'state-senate-districts',
-				'source-layer': 'state_senate_districts-0g2odu',
-				'paint': {
-					'fill-color': 'rgba(200, 100, 240, 0)',
-					'fill-outline-color': 'rgba(200, 100, 240, 0)'
-				},
+				'sourceName': 'state-house-districts',
+				'sourceID': 'state_house_districts-1vl4x8',
+				'sourceURL': 'mapbox://core-gis.9drnaiu0',
+				'lineLayerName': 'state-house-districts-lines',
+				'lineColor': 'rgba(117, 137, 77, 0.5)',
+				'legendID': 'state_house_districts',
+				'displayBehind': 'districts-of-innovation-points',
+				'polygonLayerName': 'state-house-districts-poly'
 			}
 		);
 
@@ -511,43 +503,6 @@
 			},
 			'districts-of-innovation-points'
 		);
-
-
-		map.addSource('state-house-districts', {
-			type: 'vector',
-			url: 'mapbox://core-gis.9drnaiu0'
-		});
-		map.addLayer(
-			{
-				'id': 'state-house-districts-lines',
-				'type': 'line',
-				'source': 'state-house-districts',
-				'source-layer': 'state_house_districts-1vl4x8',
-				'layout': {
-					'visibility': 'none',
-					'line-join': 'round',
-					'line-cap': 'round'
-				},
-				'paint': {
-					'line-color': 'rgba(117,137,77,0.5)',
-					'line-width': 1
-				},
-			},
-			'districts-of-innovation-points'
-		);
-		map.addLayer(
-			{
-				'id': 'state-house-districts-poly',
-				'type': 'fill',
-				'source': 'state-house-districts',
-				'source-layer': 'state_house_districts-1vl4x8',
-				'paint': {
-					'fill-color': 'rgba(200, 100, 240, 0)',
-					'fill-outline-color': 'rgba(200, 100, 240, 0)'
-				},
-			}
-		);
-
 		runWhenLoadComplete();
 
 	});

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -173,15 +173,15 @@
 </div>
 
 <script>
-function openNav() {
-    document.getElementById("mySidenav").style.width = "300px";
-    document.getElementById("main").style.marginLeft = "300px";
-}
+	function openNav() {
+		document.getElementById("mySidenav").style.width = "300px";
+		document.getElementById("main").style.marginLeft = "300px";
+	}
 
-function closeNav() {
-    document.getElementById("mySidenav").style.width = "0";
-    document.getElementById("main").style.marginLeft= "0";
-}
+	function closeNav() {
+		document.getElementById("mySidenav").style.width = "0";
+		document.getElementById("main").style.marginLeft= "0";
+	}
 </script>
 
 <!--END FLYOUT FOR 'ZOOM TO LAYERS'-->
@@ -264,8 +264,8 @@ function addPointLayer(map, gusID, sourceName, layerName, icon, iconSize, legend
 }
 
 /*
-	Updated method for adding point layers using the GUS API:
-	Simply call the addPointLayer() function with arguments like the examples below.  The final argument is optional: set it to true if you want the layer visible before the user does anything; otherwise it's hidden until they click to activate it.
+	How to add point layers using the GUS API:
+	Call the addPointLayer() function with arguments like the examples below.  The final argument is optional: set it to true if you want the layer visible before the user does anything; otherwise it's hidden until they click to activate it.
 */
 
 map.on('load', function () {
@@ -517,22 +517,21 @@ map.on('load', function () {
 // This is the popup for the merged boundary layers
 // When a click event occurs on a feature in the unioned districts layer, open a popup at the
 // location of the click, with description HTML from its properties.
-    map.on('click', 'school_house_senate_districts_UNION-poly', function (e) {
-        new mapboxgl.Popup()
-            .setLngLat(e.lngLat)
-            .setHTML(fillpopup(e.features[0].properties))
-            .addTo(map);
-//		console.log(e.features[0].properties);
-    });
+	map.on('click', 'school_house_senate_districts_UNION-poly', function (e) {
+		new mapboxgl.Popup()
+			.setLngLat(e.lngLat)
+			.setHTML(fillpopup(e.features[0].properties))
+			.addTo(map);
+	});
 
 	 // Change the cursor to a pointer when the mouse is over the house districts layer.
     map.on('mouseenter', 'school_house_senate_districts_UNION-poly', function () {
-        map.getCanvas().style.cursor = 'pointer';
+			map.getCanvas().style.cursor = 'pointer';
     });
 
     // Change it back to a pointer when it leaves.
     map.on('mouseleave', 'school_house_senate_districts_UNION-poly', function () {
-        map.getCanvas().style.cursor = '';
+			map.getCanvas().style.cursor = '';
     });
 
 	function fillpopup(data){
@@ -553,17 +552,17 @@ map.on('load', function () {
 
 
 function fetchJSONFile(path, callback) {
-    var httpRequest = new XMLHttpRequest();
-    httpRequest.onreadystatechange = function() {
-        if (httpRequest.readyState === 4) {
-            if (httpRequest.status === 200) {
-                var data = JSON.parse(httpRequest.responseText);
-                if (callback) callback(data);
-            }
-        }
-    };
-    httpRequest.open('GET', path);
-    httpRequest.send();
+	var httpRequest = new XMLHttpRequest();
+	httpRequest.onreadystatechange = function() {
+		if (httpRequest.readyState === 4) {
+			if (httpRequest.status === 200) {
+				var data = JSON.parse(httpRequest.responseText);
+				if (callback) callback(data);
+			}
+		}
+	};
+	httpRequest.open('GET', path);
+	httpRequest.send();
 }
 
 function gus_api(id, callback) {
@@ -627,7 +626,6 @@ function gus_api(id, callback) {
       gj.features.push(feature);
     }
 
-//		console.log(JSON.stringify(gj));
     callback(gj);
   });
 };

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -232,46 +232,46 @@
 	var originalZoomLevel = map.getZoom();
 
 
-
-	function addPointLayer(map, gusID, sourceName, layerName, icon, iconSize, legendid, visibleOnLoad) {
-		gus_api(gusID, function(jsondata) {
-			if ((visibleOnLoad === undefined) || (visibleOnLoad === false)) {
+// params: gusID, sourceName, layerName, icon, iconSize, legendID, visibleOnLoad
+	function addPointLayer(map, params) {
+		gus_api(params.gusID, function(jsondata) {
+			if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
 				var visibilityState = 'none';
-				document.getElementById(legendid).classList.add('inactive');
+				document.getElementById(params.legendID).classList.add('inactive');
 			}	else {
 				var visibilityState = 'visible';
-				document.getElementById(legendid).classList.remove('inactive');
+				document.getElementById(params.legendID).classList.remove('inactive');
 			}
-			map.addSource(sourceName, {
+			map.addSource(params.sourceName, {
 				type: 'geojson',
 				data: jsondata
 			});
 			map.addLayer({
-				'id': layerName,
+				'id': params.layerName,
 				'type': 'symbol',
-				'source': sourceName,
-				layout: {
-					'icon-image': icon,
-					'icon-size': iconSize,
+				'source': params.sourceName,
+				'layout': {
+					'icon-image': params.icon,
+					'icon-size': params.iconSize,
 					'icon-allow-overlap': true,
 					'visibility': visibilityState
 				}
 			});
 			map.on("zoomend", function(){
-				map.setLayoutProperty(layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * iconSize);
+				map.setLayoutProperty(params.layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * params.iconSize);
 			});
 		});
 	}
 
-// map, sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendid, displayBehind, polygonLayerName, visibleOnLoad
-	function addVectorLayer(params) {
+// params: sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendID, displayBehind, polygonLayerName, visibleOnLoad
+	function addVectorLayer(map, params) {
 		console.log(params);
 		if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
 			var visibilityState = 'none';
-			document.getElementById(params.legendid).classList.add('inactive');
+			document.getElementById(params.legendID).classList.add('inactive');
 		}	else {
 			var visibilityState = 'visible';
-			document.getElementById(params.legendid).classList.remove('inactive');
+			document.getElementById(params.legendID).classList.remove('inactive');
 		}
 		map.addSource(params.sourceName, {
 			type: 'vector',
@@ -321,66 +321,81 @@
 	*/
 
 	map.on('load', function () {
+
+// params: gusID, sourceName, layerName, icon, iconSize, legendID, visibleOnLoad
 		addPointLayer(
 			map,
-			"1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
-			'raising-family-partnerships', // this one will be the data source name
-			'raising-family-partnerships-points', // layer name
-			'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
-			0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
-			'raising_family_partnerships' // this one will be the id in the legend
+			{
+				'gusID': "1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
+				'sourceName': 'raising-family-partnerships', // this one will be the data source name
+				'layerName': 'raising-family-partnerships-points', // layer name
+				'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
+				'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
+				'legendID': 'raising_family_partnerships', // this one will be the id in the legend
+				'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
+			}
 		);
 
 		addPointLayer(
 			map,
-			"1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE",
-			'raising-blended-learners',
-			'raising-blended-learners-points',
-			'raising_blended_learners_large',
-			0.1,
-			'raising_blended_learners'
+			{
+				'gusID': '1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE',
+				'sourceName': 'raising-blended-learners',
+				'layerName': 'raising-blended-learners-points',
+				'icon': 'raising_blended_learners_large',
+				'iconSize': 0.1,
+				'legendID': 'raising_blended_learners'
+			}
 		);
 
 		addPointLayer(
 			map,
-			"1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
-			'charles-butt-scholars',
-			'charles-butt-scholars-points',
-			'charles_butt_scholars_large',
-			0.1,
-			'charles_butt_scholars',
-			true // set the optional final argument to true to have the layer visible on load
+			{
+				'gusID': "1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
+				'sourceName': 'charles-butt-scholars',
+				'layerName': 'charles-butt-scholars-points',
+				'icon': 'charles_butt_scholars_large',
+				'iconSize': 0.1,
+				'legendID': 'charles_butt_scholars'
+			}
 		);
 
 		addPointLayer(
 			map,
-			"1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
-			'raising-texas-teachers',
-			'raising-texas-teachers-points',
-			'raising_texas_teachers_large',
-			0.1,
-			'raising_texas_teachers'
+			{
+				'gusID': "1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
+				'sourceName': 'raising-texas-teachers',
+				'layerName': 'raising-texas-teachers-points',
+				'icon': 'raising_texas_teachers_large',
+				'iconSize': 0.1,
+				'legendID': 'raising_texas_teachers'
+			}
 		);
 
 		addPointLayer(
 			map,
-			"1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
-			'raising-school-leaders',
-			'raising-school-leaders-points',
-			'raising_school_leaders_large',
-			0.1,
-			'raising_school_leaders'
+			{
+				'gusID': "1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
+				'sourceName': 'raising-school-leaders',
+				'layerName': 'raising-school-leaders-points',
+				'icon': 'raising_school_leaders_large',
+				'iconSize': 0.1,
+				'legendID': 'raising_school_leaders'
+			}
 		);
 
 		addPointLayer(
 			map,
-			"1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
-			'districts-of-innovation',
-			'districts-of-innovation-points',
-			'districts_of_innovation_large',
-			0.1,
-			'districts_of_innovation'
+			{
+				'gusID': "1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
+				'sourceName': 'districts-of-innovation',
+				'layerName': 'districts-of-innovation-points',
+				'icon': 'districts_of_innovation_large',
+				'iconSize': 0.1,
+				'legendID': 'districts_of_innovation'
+			}
 		);
+
 
 		/*
 		//Attempting to add in the Districts of Innovation as polygons
@@ -427,18 +442,20 @@
 		*/
 
 
-		addVectorLayer({
-			'map': map,
-			'sourceName': 'texas-school-districts',
-			'sourceID': 'texas_school_districts_v2',
-			'sourceURL': 'mapbox://core-gis.e4af0de1',
-			'lineLayerName': 'texas-school-districts-lines',
-			'lineColor': '#a1b082',
-			'legendid': 'texas_school_districts',
-			'displayBehind': 'districts-of-innovation-points',
-			'polygonLayerName': 'texas-school-districts-poly',
-			'visibleOnLoad': false
-		});
+		addVectorLayer(
+			map,
+			{
+				'sourceName': 'texas-school-districts',
+				'sourceID': 'texas_school_districts_v2',
+				'sourceURL': 'mapbox://core-gis.e4af0de1',
+				'lineLayerName': 'texas-school-districts-lines',
+				'lineColor': '#a1b082',
+				'legendID': 'texas_school_districts',
+				'displayBehind': 'districts-of-innovation-points',
+				'polygonLayerName': 'texas-school-districts-poly',
+				'visibleOnLoad': false
+			}
+		);
 
 
 		map.addSource('state-senate-districts', {

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html>
+
+
+
 <head>
     <meta charset='utf-8' />
     <title>Raise Your Hand Texas Internal Web Map</title>
@@ -54,7 +57,7 @@ function runWhenLoadComplete() {
 			for (i in polygonNames) {
 				select.options[select.options.length] = new Option(polygonNames[i], polygonNames[i]);
 			}
-			showHideLayer(sourceID+"-lines", sourceID.replace("-", "_").replace("-", "_"));
+//			showHideLayer(sourceID+"-lines", sourceID.replace("-", "_").replace("-", "_"));
 		}
 
 		function getIDsList(sourceID, fieldName) {
@@ -199,9 +202,9 @@ function closeNav() {
 				<!--
 				<li onClick="showHideLayer('districts-of-innovation-poly-lines', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly"></span>Districts of Innovation Poly</li>
 				-->
-				<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts"></span>Texas School Districts</li>
-				<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts"></span>State House Districts</li>
-				<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts"></span>State Senate Districts</li>
+				<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
+				<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
+				<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
 			  </ul>
 		</div>
 		<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/"  target="_blank">Raise Your Hand Texas</a></div>
@@ -376,7 +379,7 @@ map.on('load', function () {
 
 	//End Districts of Innovation as poly
 	*/
-	
+
 	map.addSource('texas-school-districts', {
 		type: 'vector',
 		url: 'mapbox://core-gis.e4af0de1'
@@ -388,7 +391,7 @@ map.on('load', function () {
 			'source': 'texas-school-districts',
 			'source-layer': 'texas_school_districts_v2',
 			'layout': {
-				'visibility': 'visible',
+				'visibility': 'none',
 				'line-join': 'round',
 				'line-cap': 'round'
 			},
@@ -426,7 +429,7 @@ map.on('load', function () {
 			'source': 'state-senate-districts',
 			'source-layer': 'state_senate_districts-0g2odu',
 			'layout': {
-				'visibility': 'visible',
+				'visibility': 'none',
 				'line-join': 'round',
 				'line-cap': 'round'
 			},
@@ -486,7 +489,7 @@ map.on('load', function () {
 			'source': 'state-house-districts',
 			'source-layer': 'state_house_districts-1vl4x8',
 			'layout': {
-				'visibility': 'visible',
+				'visibility': 'none',
 				'line-join': 'round',
 				'line-cap': 'round'
 			},

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -245,7 +245,6 @@
 		}
 	}
 
-// params: gusID, sourceName, layerName, icon, iconSize, legendID, visibleOnLoad
 	function addPointLayer(map, params) {
 		gus_api(params.gusID, function(jsondata) {
 			var visibilityState = setVisibilityState(params);
@@ -270,7 +269,6 @@
 		});
 	}
 
-// params: sourceName, sourceID, sourceURL, lineLayerName, lineColor, legendID, displayBehind, polygonLayerName, visibleOnLoad
 	function addVectorLayer(map, params) {
 		var visibilityState = setVisibilityState(params);
 		map.addSource(params.sourceName, {
@@ -305,8 +303,8 @@
 					'source': params.sourceName,
 					'source-layer': params.sourceID,
 					'paint': {
-						'fill-color': 'rgba(200, 100, 240, 0)',
-						'fill-outline-color': 'rgba(200, 100, 240, 0)'
+						'fill-color': params.polygonFillColor,
+						'fill-outline-color': params.polygonOutlineColor
 					},
 				}
 			);
@@ -317,10 +315,11 @@
 
 	/*
 		How to add point layers using the GUS API:
-		Call the addPointLayer() function with arguments like the examples below.  The final argument is optional: set it to true if you want the layer visible before the user does anything; otherwise it's hidden until they click to activate it.
+		Call the addPointLayer() function with arguments like the examples below.
 
 		How to add vector layers using Mapbox:
-		Call the addVectorLayer() function with arguments like the examples below.  Note that these calls have to be after the addPointLayer() ones, because they will reference at least one of the point layers as a way of making sure polygons get drawn behind points.
+		Call the addVectorLayer() function with arguments like the examples below.
+		Note that these calls have to be after the addPointLayer() ones, because they will reference at least one of the point layers as a way of making sure polygons get drawn behind points.
 	*/
 
 	map.on('load', function () {
@@ -331,7 +330,7 @@
 				'sourceName': 'raising-family-partnerships', // this one will be the data source name
 				'layerName': 'raising-family-partnerships-points', // layer name
 				'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
-				'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
+				'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended initial display size, so that when it gets scaled up on zooming in it will still look good
 				'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
 				'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
 			}
@@ -454,6 +453,8 @@
 				'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
 				'displayBehind': 'districts-of-innovation-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
 				'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.  Leave out or set to false if you don't want one.
+				'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
+				'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
 				'visibleOnLoad': false // set this optional argument to true to have the layer visible on load.  Leave out or set to false to have it hidden on load
 			}
 		);
@@ -468,7 +469,9 @@
 				'lineColor': '#a1b082',
 				'legendID': 'state_senate_districts',
 				'displayBehind': 'districts-of-innovation-points',
-				'polygonLayerName': 'state-senate-districts-poly'
+				'polygonLayerName': 'state-senate-districts-poly',
+				'polygonFillColor': 'rgba(200, 100, 240, 0)',
+				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
 			}
 		);
 
@@ -482,7 +485,9 @@
 				'lineColor': 'rgba(117, 137, 77, 0.5)',
 				'legendID': 'state_house_districts',
 				'displayBehind': 'districts-of-innovation-points',
-				'polygonLayerName': 'state-house-districts-poly'
+				'polygonLayerName': 'state-house-districts-poly',
+				'polygonFillColor': 'rgba(200, 100, 240, 0)',
+				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
 			}
 		);
 
@@ -494,7 +499,9 @@
 				'sourceID': 'school_house_senate_districts_UNION',
 				'sourceURL': 'mapbox://core-gis.a81c8ecf',
 				'displayBehind': 'districts-of-innovation-points',
-				'polygonLayerName': 'school_house_senate_districts_UNION-poly'
+				'polygonLayerName': 'school_house_senate_districts_UNION-poly',
+				'polygonFillColor': 'rgba(200, 100, 240, 0)',
+				'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
 			}
 		);
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -15,11 +15,11 @@
 -->
 
 	<head>
-    <meta charset='utf-8' />
-    <title>Raise Your Hand Texas Internal Web Map</title>
-    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
+		<meta charset='utf-8' />
+		<title>Raise Your Hand Texas Internal Web Map</title>
+		<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+		<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+		<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
 		<link href="css/ryht-internal-style.css" rel="stylesheet" />
 		<style>
 			body { margin:0; padding:0; }
@@ -149,7 +149,7 @@
 				<br /><br /><br />
 			</p>
 			<p class="moreinfo">
-				Use the drop-down menus below to zoom to a School District, House District, or Senate District of your choice. Choose  the top entry on any drop down to return to the full extent of the state.
+				Use the drop-down menus below to zoom to a School District, House District, or Senate District of your choice. Choose the top entry on any drop down to return to the full extent of the state.
 				<br /><br />
 
 				<!--Drop down controls-->
@@ -209,8 +209,8 @@
 						<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
 					</ul>
 				</div>
-				<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/"  target="_blank">Raise Your Hand Texas</a></div>
-				<div class='map-credit'>Map design by <a href="http://www.coregis.net/"  target="_blank">CORE GIS</a></div>
+				<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/" target="_blank">Raise Your Hand Texas</a></div>
+				<div class='map-credit'>Map design by <a href="http://www.coregis.net/" target="_blank">CORE GIS</a></div>
 			</div>
 		</div>
 
@@ -224,11 +224,11 @@
 				];
 
 			var map = new mapboxgl.Map({
-					container: 'map', // container id
-					style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
-					center: [-98.887939,31.821565], // starting position [lng, lat]
-					zoom: 5.5, // starting zoom
-				maxBounds:  bounds // sets bounds as max
+				container: 'map', // container id
+				style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
+				center: [-98.887939,31.821565], // starting position [lng, lat]
+				zoom: 5.5, // starting zoom
+				maxBounds: bounds // sets bounds as max
 
 			});
 
@@ -240,7 +240,7 @@
 						document.getElementById(params.legendID).classList.add('inactive');
 					}
 					return 'none';
-				}	else {
+				} else {
 					if ((params.legendID !== undefined) && (params.legendID !== false)) {
 						document.getElementById(params.legendID).classList.remove('inactive');
 					}
@@ -337,7 +337,7 @@
 						'layerName': 'raising-family-partnerships-points', // layer name
 						'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
 						'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended initial display size, so that when it gets scaled up on zooming in it will still look good
-						'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
+						'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate. Simply leave out for layers that don't appear in the legend
 						'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
 					}
 				);
@@ -409,14 +409,14 @@
 						'sourceName': 'texas-school-districts', // data source name for internal use
 						'sourceID': 'texas_school_districts_v2', // name of the Mapbox layer from which the data will be loaded
 						'sourceURL': 'mapbox://core-gis.e4af0de1', // Mapbox URL
-						'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines.  Leave out or set to false if you don't want outlines displayed.
+						'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines. Leave out or set to false if you don't want outlines displayed.
 						'lineColor': '#a1b082', // colour to draw those outlines with; safe to leave out if we're not drawing outlines, but must be explicitly set if we are
-						'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate.  Simply leave out for layers that don't appear in the legend
+						'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate. Simply leave out for layers that don't appear in the legend
 						'displayBehind': 'raising-school-leaders-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
-						'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.  Leave out or set to false if you don't want one.
+						'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.	Leave out or set to false if you don't want one.
 						'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
 						'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
-						'visibleOnLoad': false // set this optional argument to true to have the layer visible on load.  Leave out or set to false to have it hidden on load
+						'visibleOnLoad': false // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
 					}
 				);
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -2,7 +2,6 @@
 <html>
 
 
-
 <head>
     <meta charset='utf-8' />
     <title>Raise Your Hand Texas Internal Web Map</title>
@@ -39,16 +38,16 @@
 //getIDsList() does the actual work of fetching the district names
 //zoomToPolygon() zooms the map to the district extent
 
-	function runWhenLoadComplete() {
-		if (!map.loaded()) {
-			setTimeout(runWhenLoadComplete, 100);
+		function runWhenLoadComplete() {
+			if (!map.loaded()) {
+				setTimeout(runWhenLoadComplete, 100);
+			}
+			else {
+				populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
+				populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
+				populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
+			}
 		}
-		else {
-			populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
-			populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
-			populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
-		}
-	}
 
 		function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 			polygonNames = getIDsList(sourceID, fieldName);
@@ -191,7 +190,7 @@
 <div class='legend'>
 	<div class='legend-title'>Click on a layer name below to toggle its visibility</div>
 		<div class='legend-scale'>
-			  <ul class='legend-labels'>
+			<ul class='legend-labels'>
 				<li onClick="showHideLayer('raising-blended-learners-points', markerName='raising_blended_learners');"><span id="raising_blended_learners" class="inactive"></span>Raising Blended Learners</li>
 				<li onClick="showHideLayer('raising-family-partnerships-points', markerName='raising_family_partnerships');"><span id="raising_family_partnerships" class="inactive"></span>Raising Family Partnerships</li>
 				<li onClick="showHideLayer('charles-butt-scholars-points', markerName='charles_butt_scholars');"><span id="charles_butt_scholars" class="inactive"></span>Charles Butt Scholars</li>
@@ -204,7 +203,7 @@
 				<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
 				<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
 				<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
-			  </ul>
+			</ul>
 		</div>
 		<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/"  target="_blank">Raise Your Hand Texas</a></div>
 		<div class='map-credit'>Map design by <a href="http://www.coregis.net/"  target="_blank">CORE GIS</a></div>

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -1,6 +1,18 @@
 <!DOCTYPE html>
 <html>
 
+<!--
+	WHERE THINGS ARE DEFINED IN THIS FILE:
+
+	Layers are added in the map.on('load') call towards the end.
+
+	For a layer to appear in the legend, it must have a corresponding <li> in <ul class='legend-labels'>, and the id for that item has to be given to addPointLayer() or addVectorLayer() as the legendID property.
+	For a legend item to show the right icon, there must be a corresponding rule set in css/ryht-internal-style.css
+
+	For a layer to appear in the Zoom to Districts control, it must have a polygon layer (even if that's kept invisible) and have two corresponding definitions:
+		1) a <select> element defined in the section of <div id="mySidenav"> that's labelled with the comment: !--Drop down controls--
+		2) a populateZoomControl() line in the runWhenLoadComplete() function
+-->
 
 <head>
     <meta charset='utf-8' />

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -18,19 +18,19 @@
 		font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 </style>
+
 	<script>
 		function showHideLayer(layerName, markerName) {
 			var visibility = map.getLayoutProperty(layerName, 'visibility');
-//			console.log(layerName, visibility);
         if (visibility === 'visible') {
-            map.setLayoutProperty(layerName, 'visibility', 'none');
-            this.className = '';
-			document.getElementById(markerName).classList.add('inactive');
+					map.setLayoutProperty(layerName, 'visibility', 'none');
+					this.className = '';
+				document.getElementById(markerName).classList.add('inactive');
         } else {
-            this.className = 'active';
-            map.setLayoutProperty(layerName, 'visibility', 'visible');
-			document.getElementById(markerName).classList.remove('inactive');
-        }
+					this.className = 'active';
+					map.setLayoutProperty(layerName, 'visibility', 'visible');
+				document.getElementById(markerName).classList.remove('inactive');
+			}
 		}
 
 //These are the four functions written by Eldan that power the zoom-to-district feature
@@ -39,16 +39,16 @@
 //getIDsList() does the actual work of fetching the district names
 //zoomToPolygon() zooms the map to the district extent
 
-function runWhenLoadComplete() {
-			if (!map.loaded()) {
-				setTimeout(runWhenLoadComplete, 100);
-			}
-			else {
-				populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
-				populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
-				populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
-			}
+	function runWhenLoadComplete() {
+		if (!map.loaded()) {
+			setTimeout(runWhenLoadComplete, 100);
 		}
+		else {
+			populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
+			populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
+			populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
+		}
+	}
 
 		function populateZoomControl(selectID, sourceID, fieldName, layerName) {
 			polygonNames = getIDsList(sourceID, fieldName);
@@ -57,7 +57,6 @@ function runWhenLoadComplete() {
 			for (i in polygonNames) {
 				select.options[select.options.length] = new Option(polygonNames[i], polygonNames[i]);
 			}
-//			showHideLayer(sourceID+"-lines", sourceID.replace("-", "_").replace("-", "_"));
 		}
 
 		function getIDsList(sourceID, fieldName) {
@@ -231,17 +230,6 @@ var map = new mapboxgl.Map({
 });
 
 var originalZoomLevel = map.getZoom();
-/*
-var layers = map.getStyle().layers;
-    // Find the index of the first symbol layer in the map style
-    var firstSymbolId;
-    for (var i = 0; i < layers.length; i++) {
-        if (layers[i].type === 'symbol') {
-            firstSymbolId = layers[i].id;
-            break;
-        }
-    }
-*/
 
 
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -244,7 +244,7 @@
 					if ((params.legendID !== undefined) && (params.legendID !== false)) {
 						document.getElementById(params.legendID).classList.remove('inactive');
 					}
-					return 'visible'
+					return 'visible';
 				}
 			}
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -212,307 +212,312 @@
 </div>
 
 <script>
-mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
+	mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
 
-//set bounds to Texas
-var bounds = [
-		[-114.9594,21.637], // southwest coords
-		[-85.50,39.317] // northeast coords
-	];
+	//set bounds to Texas
+	var bounds = [
+			[-114.9594,21.637], // southwest coords
+			[-85.50,39.317] // northeast coords
+		];
 
-var map = new mapboxgl.Map({
-    container: 'map', // container id
-    style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
-    center: [-98.887939,31.821565], // starting position [lng, lat]
-    zoom: 5.5, // starting zoom
-	maxBounds:  bounds // sets bounds as max
+	var map = new mapboxgl.Map({
+			container: 'map', // container id
+			style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
+			center: [-98.887939,31.821565], // starting position [lng, lat]
+			zoom: 5.5, // starting zoom
+		maxBounds:  bounds // sets bounds as max
 
-});
-
-var originalZoomLevel = map.getZoom();
-
-
-
-function addPointLayer(map, gusID, sourceName, layerName, icon, iconSize, legendid, visibleOnLoad) {
-	gus_api(gusID, function(jsondata) {
-		if ((visibleOnLoad === undefined) || (visibleOnLoad === false)) {
-			var visibilityState = 'none';
-			document.getElementById(legendid).classList.add('inactive');
-		}	else {
-			var visibilityState = 'visible';
-			document.getElementById(legendid).classList.remove('inactive');
-		}
-		map.addSource(sourceName, {
-			type: 'geojson',
-			data: jsondata
-		});
-		map.addLayer({
-			'id': layerName,
-			'type': 'symbol',
-			'source': sourceName,
-			layout: {
-				'icon-image': icon,
-				'icon-size': iconSize,
-				'icon-allow-overlap': true,
-				'visibility': visibilityState
-			}
-		});
-		map.on("zoomend", function(){
-			map.setLayoutProperty(layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * iconSize);
-		});
 	});
-}
 
-/*
-	How to add point layers using the GUS API:
-	Call the addPointLayer() function with arguments like the examples below.  The final argument is optional: set it to true if you want the layer visible before the user does anything; otherwise it's hidden until they click to activate it.
-*/
+	var originalZoomLevel = map.getZoom();
 
-map.on('load', function () {
-	addPointLayer(
-		map,
-		"1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
-		'raising-family-partnerships', // this one will be the data source name
-		'raising-family-partnerships-points', // layer name
-		'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
-		0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
-		'raising_family_partnerships' // this one will be the id in the legend
-	);
 
-	addPointLayer(
-		map,
-		"1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE",
-		'raising-blended-learners',
-		'raising-blended-learners-points',
-		'raising_blended_learners_large',
-		0.1,
-		'raising_blended_learners'
-	);
 
-	addPointLayer(
-		map,
-		"1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
-		'charles-butt-scholars',
-		'charles-butt-scholars-points',
-		'charles_butt_scholars_large',
-		0.1,
-		'charles_butt_scholars',
-		true // set the optional final argument to true to have the layer visible on load
-	);
+	function addPointLayer(map, gusID, sourceName, layerName, icon, iconSize, legendid, visibleOnLoad) {
+		gus_api(gusID, function(jsondata) {
+			if ((visibleOnLoad === undefined) || (visibleOnLoad === false)) {
+				var visibilityState = 'none';
+				document.getElementById(legendid).classList.add('inactive');
+			}	else {
+				var visibilityState = 'visible';
+				document.getElementById(legendid).classList.remove('inactive');
+			}
+			map.addSource(sourceName, {
+				type: 'geojson',
+				data: jsondata
+			});
+			map.addLayer({
+				'id': layerName,
+				'type': 'symbol',
+				'source': sourceName,
+				layout: {
+					'icon-image': icon,
+					'icon-size': iconSize,
+					'icon-allow-overlap': true,
+					'visibility': visibilityState
+				}
+			});
+			map.on("zoomend", function(){
+				map.setLayoutProperty(layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * iconSize);
+			});
+		});
+	}
 
-	addPointLayer(
-		map,
-		"1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
-		'raising-texas-teachers',
-		'raising-texas-teachers-points',
-		'raising_texas_teachers_large',
-		0.1,
-		'raising_texas_teachers'
-	);
 
-	addPointLayer(
-		map,
-		"1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
-		'raising-school-leaders',
-		'raising-school-leaders-points',
-		'raising_school_leaders_large',
-		0.1,
-		'raising_school_leaders'
-	);
-
-	addPointLayer(
-		map,
-		"1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
-		'districts-of-innovation',
-		'districts-of-innovation-points',
-		'districts_of_innovation_large',
-		0.1,
-		'districts_of_innovation'
-	);
 
 	/*
-	//Attempting to add in the Districts of Innovation as polygons
-	map.addSource('districts-of-innovation-poly', {
-		type: 'vector',
-		url: 'mapbox://core-gis.97b01c24'
-	});
-	map.addLayer(
-		{
-			'id': 'districts-of-innovation-poly-lines',
-			'type': 'line',
-			'source': 'districts-of-innovation-poly',
-			'source-layer': 'districts_of_innovation_poly_v1',
-			'layout': {
-				'visibility': 'visible',
-				'line-join': 'round',
-				'line-cap': 'round'
-			},
-			'paint': {
-				'line-color': '#f7f7c6',
-				'line-width': 1
-			},
-		},
-		'districts-of-innovation-points'
-	);
-	map.addLayer(
-		{
-			'id': 'districts-of-innovation-poly-fill',
-			'type': 'fill',
-			'source': 'districts-of-innovation-poly',
-			'source-layer': 'districts_of_innovation_poly_v1',
-			'layout': {
-
-
-			},
-			'paint': {
-				'fill-color': 'rgba(247, 247, 198, 100)',
-				'fill-outline-color': 'rgba(194, 194, 126, 100)'
-			},
-		}
-	);
-
-	//End Districts of Innovation as poly
+		How to add point layers using the GUS API:
+		Call the addPointLayer() function with arguments like the examples below.  The final argument is optional: set it to true if you want the layer visible before the user does anything; otherwise it's hidden until they click to activate it.
 	*/
 
-	map.addSource('texas-school-districts', {
-		type: 'vector',
-		url: 'mapbox://core-gis.e4af0de1'
+	map.on('load', function () {
+		addPointLayer(
+			map,
+			"1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
+			'raising-family-partnerships', // this one will be the data source name
+			'raising-family-partnerships-points', // layer name
+			'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
+			0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended display size, so that when it gets scaled up on zooming in it will still look good
+			'raising_family_partnerships' // this one will be the id in the legend
+		);
+
+		addPointLayer(
+			map,
+			"1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE",
+			'raising-blended-learners',
+			'raising-blended-learners-points',
+			'raising_blended_learners_large',
+			0.1,
+			'raising_blended_learners'
+		);
+
+		addPointLayer(
+			map,
+			"1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
+			'charles-butt-scholars',
+			'charles-butt-scholars-points',
+			'charles_butt_scholars_large',
+			0.1,
+			'charles_butt_scholars',
+			true // set the optional final argument to true to have the layer visible on load
+		);
+
+		addPointLayer(
+			map,
+			"1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
+			'raising-texas-teachers',
+			'raising-texas-teachers-points',
+			'raising_texas_teachers_large',
+			0.1,
+			'raising_texas_teachers'
+		);
+
+		addPointLayer(
+			map,
+			"1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
+			'raising-school-leaders',
+			'raising-school-leaders-points',
+			'raising_school_leaders_large',
+			0.1,
+			'raising_school_leaders'
+		);
+
+		addPointLayer(
+			map,
+			"1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
+			'districts-of-innovation',
+			'districts-of-innovation-points',
+			'districts_of_innovation_large',
+			0.1,
+			'districts_of_innovation'
+		);
+
+		/*
+		//Attempting to add in the Districts of Innovation as polygons
+		map.addSource('districts-of-innovation-poly', {
+			type: 'vector',
+			url: 'mapbox://core-gis.97b01c24'
+		});
+		map.addLayer(
+			{
+				'id': 'districts-of-innovation-poly-lines',
+				'type': 'line',
+				'source': 'districts-of-innovation-poly',
+				'source-layer': 'districts_of_innovation_poly_v1',
+				'layout': {
+					'visibility': 'visible',
+					'line-join': 'round',
+					'line-cap': 'round'
+				},
+				'paint': {
+					'line-color': '#f7f7c6',
+					'line-width': 1
+				},
+			},
+			'districts-of-innovation-points'
+		);
+		map.addLayer(
+			{
+				'id': 'districts-of-innovation-poly-fill',
+				'type': 'fill',
+				'source': 'districts-of-innovation-poly',
+				'source-layer': 'districts_of_innovation_poly_v1',
+				'layout': {
+
+
+				},
+				'paint': {
+					'fill-color': 'rgba(247, 247, 198, 100)',
+					'fill-outline-color': 'rgba(194, 194, 126, 100)'
+				},
+			}
+		);
+
+		//End Districts of Innovation as poly
+		*/
+
+
+
+
+		map.addSource('texas-school-districts', {
+			type: 'vector',
+			url: 'mapbox://core-gis.e4af0de1'
+		});
+		map.addLayer(
+			{
+				'id': 'texas-school-districts-lines',
+				'type': 'line',
+				'source': 'texas-school-districts',
+				'source-layer': 'texas_school_districts_v2',
+				'layout': {
+					'visibility': 'none',
+					'line-join': 'round',
+					'line-cap': 'round'
+				},
+				'paint': {
+					'line-color': '#a1b082',
+					'line-width': 1
+				},
+			},
+			'districts-of-innovation-points'
+		);
+		map.addLayer(
+			{
+				'id': 'texas-school-districts-poly',
+				'type': 'fill',
+				'source': 'texas-school-districts',
+				'source-layer': 'texas_school_districts_v2',
+				'layout': {
+
+				},
+				'paint': {
+					'fill-color': 'rgba(200, 100, 240, 0)',
+					'fill-outline-color': 'rgba(200, 100, 240, 0)'
+				},
+			}
+		);
+
+		map.addSource('state-senate-districts', {
+			type: 'vector',
+			url: 'mapbox://core-gis.b2eu90mx'
+		});
+		map.addLayer(
+			{
+				'id': 'state-senate-districts-lines',
+				'type': 'line',
+				'source': 'state-senate-districts',
+				'source-layer': 'state_senate_districts-0g2odu',
+				'layout': {
+					'visibility': 'none',
+					'line-join': 'round',
+					'line-cap': 'round'
+				},
+				'paint': {
+					'line-color': '#a1b082',
+					'line-width': 1
+				},
+			},
+			'districts-of-innovation-points'
+		);
+		map.addLayer(
+			{
+				'id': 'state-senate-districts-poly',
+				'type': 'fill',
+				'source': 'state-senate-districts',
+				'source-layer': 'state_senate_districts-0g2odu',
+				'layout': {
+
+				},
+				'paint': {
+					'fill-color': 'rgba(200, 100, 240, 0)',
+					'fill-outline-color': 'rgba(200, 100, 240, 0)'
+				},
+			}
+		);
+
+		map.addSource('school_house_senate_districts_UNION', {
+			type: 'vector',
+			url: 'mapbox://core-gis.a81c8ecf'
+		});
+		map.addLayer(
+			{
+				'id': 'school_house_senate_districts_UNION-poly',
+				'type': 'fill',
+				'source': 'school_house_senate_districts_UNION',
+				'source-layer': 'school_house_senate_districts_UNION',
+				'layout': {
+
+				},
+				'paint': {
+					'fill-color': 'rgba(200, 100, 240, 0)',
+					'fill-outline-color': 'rgba(200, 100, 240, 0)'
+				},
+			},
+			'districts-of-innovation-points'
+		);
+
+
+		map.addSource('state-house-districts', {
+			type: 'vector',
+			url: 'mapbox://core-gis.9drnaiu0'
+		});
+		map.addLayer(
+			{
+				'id': 'state-house-districts-lines',
+				'type': 'line',
+				'source': 'state-house-districts',
+				'source-layer': 'state_house_districts-1vl4x8',
+				'layout': {
+					'visibility': 'none',
+					'line-join': 'round',
+					'line-cap': 'round'
+				},
+				'paint': {
+					'line-color': 'rgba(117,137,77,0.5)',
+					'line-width': 1
+				},
+			},
+			'districts-of-innovation-points'
+		);
+		map.addLayer(
+			{
+				'id': 'state-house-districts-poly',
+				'type': 'fill',
+				'source': 'state-house-districts',
+				'source-layer': 'state_house_districts-1vl4x8',
+				'layout': {
+
+				},
+				'paint': {
+					'fill-color': 'rgba(200, 100, 240, 0)',
+					'fill-outline-color': 'rgba(200, 100, 240, 0)'
+				},
+			}
+		);
+
+		runWhenLoadComplete();
+
 	});
-	map.addLayer(
-		{
-			'id': 'texas-school-districts-lines',
-			'type': 'line',
-			'source': 'texas-school-districts',
-			'source-layer': 'texas_school_districts_v2',
-			'layout': {
-				'visibility': 'none',
-				'line-join': 'round',
-				'line-cap': 'round'
-			},
-			'paint': {
-				'line-color': '#a1b082',
-				'line-width': 1
-			},
-		},
-		'districts-of-innovation-points'
-	);
-	map.addLayer(
-		{
-			'id': 'texas-school-districts-poly',
-			'type': 'fill',
-			'source': 'texas-school-districts',
-			'source-layer': 'texas_school_districts_v2',
-			'layout': {
-
-			},
-			'paint': {
-				'fill-color': 'rgba(200, 100, 240, 0)',
-				'fill-outline-color': 'rgba(200, 100, 240, 0)'
-			},
-		}
-	);
-
-	map.addSource('state-senate-districts', {
-		type: 'vector',
-		url: 'mapbox://core-gis.b2eu90mx'
-	});
-	map.addLayer(
-		{
-			'id': 'state-senate-districts-lines',
-			'type': 'line',
-			'source': 'state-senate-districts',
-			'source-layer': 'state_senate_districts-0g2odu',
-			'layout': {
-				'visibility': 'none',
-				'line-join': 'round',
-				'line-cap': 'round'
-			},
-			'paint': {
-				'line-color': '#a1b082',
-				'line-width': 1
-			},
-		},
-		'districts-of-innovation-points'
-	);
-	map.addLayer(
-		{
-			'id': 'state-senate-districts-poly',
-			'type': 'fill',
-			'source': 'state-senate-districts',
-			'source-layer': 'state_senate_districts-0g2odu',
-			'layout': {
-
-			},
-			'paint': {
-				'fill-color': 'rgba(200, 100, 240, 0)',
-				'fill-outline-color': 'rgba(200, 100, 240, 0)'
-			},
-		}
-	);
-
-	map.addSource('school_house_senate_districts_UNION', {
-		type: 'vector',
-		url: 'mapbox://core-gis.a81c8ecf'
-	});
-	map.addLayer(
-		{
-			'id': 'school_house_senate_districts_UNION-poly',
-			'type': 'fill',
-			'source': 'school_house_senate_districts_UNION',
-			'source-layer': 'school_house_senate_districts_UNION',
-			'layout': {
-
-			},
-			'paint': {
-				'fill-color': 'rgba(200, 100, 240, 0)',
-				'fill-outline-color': 'rgba(200, 100, 240, 0)'
-			},
-		},
-		'districts-of-innovation-points'
-	);
-
-
-	map.addSource('state-house-districts', {
-		type: 'vector',
-		url: 'mapbox://core-gis.9drnaiu0'
-	});
-	map.addLayer(
-		{
-			'id': 'state-house-districts-lines',
-			'type': 'line',
-			'source': 'state-house-districts',
-			'source-layer': 'state_house_districts-1vl4x8',
-			'layout': {
-				'visibility': 'none',
-				'line-join': 'round',
-				'line-cap': 'round'
-			},
-			'paint': {
-				'line-color': 'rgba(117,137,77,0.5)',
-				'line-width': 1
-			},
-		},
-		'districts-of-innovation-points'
-	);
-	map.addLayer(
-		{
-			'id': 'state-house-districts-poly',
-			'type': 'fill',
-			'source': 'state-house-districts',
-			'source-layer': 'state_house_districts-1vl4x8',
-			'layout': {
-
-			},
-			'paint': {
-				'fill-color': 'rgba(200, 100, 240, 0)',
-				'fill-outline-color': 'rgba(200, 100, 240, 0)'
-			},
-		}
-	);
-
-	runWhenLoadComplete();
-
-});
 
 // This is the popup for the merged boundary layers
 // When a click event occurs on a feature in the unioned districts layer, open a popup at the


### PR DESCRIPTION
This set of changes is going to be hard to follow as a whole, though individual commits should make more sense.  Here are the important bits:

- Changed the style of addPointLayer() so that the arguments we pass to it have names.  This is wordier, but will be less confusing to work with.
- Made the magnification factor for icons into an argument so that we don't have to remember to make two numbers match.
- Created an addVectorLayer() function that does the same thing for mapbox line/polygon layers, and converted the existing vector layers to use it.
- Added Districts of Innovation polygons using the new addVectorLayer() and commented out the points version.
- Switched the Charles Butt Scholars layer to being off by default.
- Lots of finicky code layout consistency stuff.
- Added and clarified code comments for future reference.

I think that with this we have something that's ready to train the client on - the main effect of these changes should be to make their job easier.