### PR TITLE
Fixed zoom control bug

### DIFF
--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -305,6 +305,7 @@
 					);
 				}
 				if ((params.polygonLayerName !== undefined) && (params.polygonLayerName !== false)) {
+					if (params.usedInZoomControl) { visibilityState = 'visible'; }
 					map.addLayer(
 						{
 							'id': params.polygonLayerName,
@@ -422,7 +423,8 @@
 						'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.	Leave out or set to false if you don't want one.
 						'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
 						'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
-						'visibleOnLoad': false // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
+						'visibleOnLoad': false, // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
+						'usedInZoomControl': true // set this optional argument to true if this layer will be used in the Zoom to Districts control, otherwise leave it out or set it to false.
 					}
 				);
 
@@ -438,7 +440,8 @@
 						'displayBehind': 'raising-school-leaders-points',
 						'polygonLayerName': 'state-senate-districts-poly',
 						'polygonFillColor': 'rgba(200, 100, 240, 0)',
-						'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)',
+						'usedInZoomControl': true
 					}
 				);
 
@@ -454,7 +457,8 @@
 						'displayBehind': 'raising-school-leaders-points',
 						'polygonLayerName': 'state-house-districts-poly',
 						'polygonFillColor': 'rgba(200, 100, 240, 0)',
-						'polygonOutlineColor': 'rgba(200, 100, 240, 0)'
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)',
+						'usedInZoomControl': true
 					}
 				);
 

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -62,9 +62,7 @@
 			}
 
 			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
-				console.log(selectID, sourceID, fieldName, layerName);
 				polygonNames = getIDsList(sourceID, fieldName);
-				console.log(polygonNames);
 				var select = document.getElementById(selectID);
 				select.options[0] = new Option(layerName);
 				for (i in polygonNames) {
@@ -74,11 +72,7 @@
 
 			function getIDsList(sourceID, fieldName) {
 				layerID = map.getSource(sourceID).vectorLayerIds[0];
-				console.log(map.getSource(sourceID).vectorLayerIds);
-				console.log(layerID);
-				console.log(map.getSource(sourceID));
 				features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
-				console.log(features);
 				featureNames = []
 				for (i in features) {
 					featureName = features[i].properties[fieldName]

--- a/gus_experiment.html
+++ b/gus_experiment.html
@@ -62,7 +62,9 @@
 			}
 
 			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
+				console.log(selectID, sourceID, fieldName, layerName);
 				polygonNames = getIDsList(sourceID, fieldName);
+				console.log(polygonNames);
 				var select = document.getElementById(selectID);
 				select.options[0] = new Option(layerName);
 				for (i in polygonNames) {
@@ -72,7 +74,11 @@
 
 			function getIDsList(sourceID, fieldName) {
 				layerID = map.getSource(sourceID).vectorLayerIds[0];
+				console.log(map.getSource(sourceID).vectorLayerIds);
+				console.log(layerID);
+				console.log(map.getSource(sourceID));
 				features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
+				console.log(features);
 				featureNames = []
 				for (i in features) {
 					featureName = features[i].properties[fieldName]


### PR DESCRIPTION
Long story short, the invisible polygon layer that populateZoomControl() uses to get the list of polygon IDs and extents has to be considered "visible" by Mapbox and only made invisible by its having an alpha value of 0.  So I had to add a little more logic to make that happen while allowing the corresponding line layer to still be hidden.