### PR TITLE
Show/hide two layers at once

### DIFF
--- a/icon-and-polygon-demo.html
+++ b/icon-and-polygon-demo.html
@@ -1,0 +1,607 @@
+<!DOCTYPE html>
+<html>
+
+<!--
+	WHERE THINGS ARE DEFINED IN THIS FILE:
+
+	Layers are added in the map.on('load') call towards the end.
+
+	For a layer to appear in the legend, it must have a corresponding <li> in <ul class='legend-labels'>, and the id for that item has to be given to addPointLayer() or addVectorLayer() as the legendID property.
+	For a legend item to show the right icon, there must be a corresponding rule set in css/ryht-internal-style.css
+
+	For a layer to appear in the Zoom to Districts control, it must have a polygon layer (even if that's kept invisible) and have two corresponding definitions:
+		1) a <select> element defined in the section of <div id="mySidenav"> that's labelled with the comment: !--Drop down controls--
+		2) a populateZoomControl() line in the runWhenLoadComplete() function
+-->
+
+	<head>
+		<meta charset='utf-8' />
+		<title>Raise Your Hand Texas Internal Web Map</title>
+		<meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+		<script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
+		<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
+		<link href="css/ryht-internal-style.css" rel="stylesheet" />
+		<style>
+			body { margin:0; padding:0; }
+			#map { position:absolute; top:0; bottom:0; width:100%; }
+			.mapboxgl-popup {
+				max-width: 400px;
+				font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+			}
+		</style>
+
+		<script>
+			function showHideLayer(layerName, markerName) {
+				var visibility = map.getLayoutProperty(layerName, 'visibility');
+					if (visibility === 'visible') {
+						map.setLayoutProperty(layerName, 'visibility', 'none');
+						this.className = '';
+					document.getElementById(markerName).classList.add('inactive');
+					} else {
+						this.className = 'active';
+						map.setLayoutProperty(layerName, 'visibility', 'visible');
+					document.getElementById(markerName).classList.remove('inactive');
+				}
+			}
+
+	//These are the four functions written by Eldan that power the zoom-to-district feature
+	// runWhenLoadComplete() checks if the map has finished loading data, and once it has then it calls the next one.
+	//populateZoomControl() fills the dropdowns with options generated from reading the data layers for all the district names.
+	//getIDsList() does the actual work of fetching the district names
+	//zoomToPolygon() zooms the map to the district extent
+
+			function runWhenLoadComplete() {
+				if (!map.loaded()) {
+					setTimeout(runWhenLoadComplete, 100);
+				}
+				else {
+					populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
+					populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
+					populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
+				}
+			}
+
+			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
+				polygonNames = getIDsList(sourceID, fieldName);
+				var select = document.getElementById(selectID);
+				select.options[0] = new Option(layerName);
+				for (i in polygonNames) {
+					select.options[select.options.length] = new Option(polygonNames[i], polygonNames[i]);
+				}
+			}
+
+			function getIDsList(sourceID, fieldName) {
+				layerID = map.getSource(sourceID).vectorLayerIds[0];
+				features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
+				featureNames = []
+				for (i in features) {
+					featureName = features[i].properties[fieldName]
+					if (typeof featureName !== undefined) {
+						if (featureNames.indexOf(featureName) < 0) {
+							featureNames.push(featureName);
+						}
+					}
+				}
+				// if the IDs are numeric we have to make sure they get sorted as numbers not as text
+				if (typeof featureNames[0] !== undefined && !isNaN(parseFloat(featureNames[0])) && isFinite(featureNames[0])) {
+					return featureNames.sort(function(a, b){return a-b});
+				}
+				else { return featureNames.sort(); }
+			}
+
+			function zoomToPolygon(sourceID, itemID, fieldName) {
+				// first quickly zoom out to the full layer area
+				map.fitBounds(map.getSource(sourceID).bounds, options={duration: 0});
+				// if we haven't passed in an itemID, then just stop there; otherwise continue with the zoom in
+				if (typeof itemID !== 'undefined') {
+					// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
+					setTimeout(
+						function(){
+							layerBounds = map.getSource(sourceID).bounds;
+							layerID = map.getSource(sourceID).vectorLayerIds[0];
+							features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
+							minX = layerBounds[2];
+							maxX = layerBounds[0];
+							minY = layerBounds[3];
+							maxY = layerBounds[1];
+							// then step through features - first to find the item we want
+							for (i in features) {
+								if (features[i].properties[fieldName] == itemID) {
+									coords = features[i].toJSON().geometry.coordinates;
+									for (j in coords) {
+										// then the coords returned may be a simple array of coords, or an array of arrays if it's a multipolygon
+										for (k in coords[j]) {
+											if (!(coords[j][k][0] instanceof Array)) {
+												if (coords[j][k][0] < minX) { minX = coords[j][k][0]; }
+												if (coords[j][k][0] > maxX) { maxX = coords[j][k][0]; }
+												if (coords[j][k][1] < minY) { minY = coords[j][k][1]; }
+												if (coords[j][k][1] > maxY) { maxY = coords[j][k][1]; }
+											}
+											else {
+												for (l in coords[j][k]) {
+													if (coords[j][k][l][0] < minX) { minX = coords[j][k][l][0]; }
+													if (coords[j][k][l][0] > maxX) { maxX = coords[j][k][l][0]; }
+													if (coords[j][k][l][1] < minY) { minY = coords[j][k][l][1]; }
+													if (coords[j][k][l][1] > maxY) { maxY = coords[j][k][l][1]; }
+												}
+											}
+										}
+									}
+								}
+							}
+							// having found the bounds, the rest is easy
+							map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
+						},
+						100
+					); // end of setTimeout block
+				}
+			}
+		</script>
+	</head>
+
+	<body>
+
+	<!--BEGIN FLYOUT FOR 'ZOOM TO LAYERS'-->
+
+		<div id="mySidenav" class="sidenav">
+			<a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+			<p>
+				<br /><br /><br />
+			</p>
+			<p class="moreinfo">
+				Use the drop-down menus below to zoom to a School District, House District, or Senate District of your choice. Choose the top entry on any drop down to return to the full extent of the state.
+				<br /><br />
+
+				<!--Drop down controls-->
+
+				<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value, 'NAME');"></select>
+				<br /><br />
+				<select id="house-districts-control" onchange="zoomToPolygon('state-house-districts', this.value, 'District');"></select>
+				<br /><br />
+				<select id="senate-districts-control" onchange="zoomToPolygon('state-senate-districts', this.value, 'District');"></select>
+
+				<br /><br />
+				Map produced by <a href="http://www.coregis.net/" target="_blank">CoreGIS</a>.
+				<br /><br />
+				<a href="https://www.raiseyourhandtexas.org/" target="_blank">Raise Your Hand Texas</a>
+				<br />
+				<a href="https://www.raiseyourhandtexas.org/contact/" target="_blank">Contact</a>
+			</p>
+		</div>
+
+		<div id="main">
+
+		<div id="about">
+			<span style="font-size:16px;cursor:pointer" onclick="openNav()">&#9776; Zoom to Districts</span>
+		</div>
+
+		<script>
+			function openNav() {
+				document.getElementById("mySidenav").style.width = "300px";
+				document.getElementById("main").style.marginLeft = "300px";
+			}
+
+			function closeNav() {
+				document.getElementById("mySidenav").style.width = "0";
+				document.getElementById("main").style.marginLeft= "0";
+			}
+		</script>
+
+	<!--END FLYOUT FOR 'ZOOM TO LAYERS'-->
+
+		<div id='map'></div>
+
+		<div class='legend'>
+			<div class='legend-title'>Click on a layer name below to toggle its visibility</div>
+				<div class='legend-scale'>
+					<ul class='legend-labels'>
+						<li onClick="showHideLayer('raising-blended-learners-points', markerName='raising_blended_learners');"><span id="raising_blended_learners" class="inactive"></span>Raising Blended Learners</li>
+						<li onClick="showHideLayer('raising-family-partnerships-points', markerName='raising_family_partnerships');"><span id="raising_family_partnerships" class="inactive"></span>Raising Family Partnerships</li>
+						<li onClick="showHideLayer('charles-butt-scholars-points', markerName='charles_butt_scholars');"><span id="charles_butt_scholars" class="inactive"></span>Charles Butt Scholars</li>
+						<li onClick="showHideLayer('raising-texas-teachers-points', markerName='raising_texas_teachers');"><span id="raising_texas_teachers" class="inactive"></span>Raising Texas Teachers</li>
+						<li onClick="showHideLayer('raising-school-leaders-points', markerName='raising_school_leaders');"><span id="raising_school_leaders" class="inactive"></span>Raising School Leaders</li>
+		<!--
+						<li onClick="showHideLayer('districts-of-innovation-points', markerName='districts_of_innovation');"><span id="districts_of_innovation" class="inactive"></span>Districts of Innovation</li>
+		-->
+						<li onClick="showHideLayer('districts-of-innovation-poly-fill', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly" class="inactive"></span>Districts of Innovation</li>
+						<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
+						<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
+						<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
+					</ul>
+				</div>
+				<div class='legend-source'>Source: <a href="https://www.raiseyourhandtexas.org/" target="_blank">Raise Your Hand Texas</a></div>
+				<div class='map-credit'>Map design by <a href="http://www.coregis.net/" target="_blank">CORE GIS</a></div>
+			</div>
+		</div>
+
+		<script>
+			mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWIHzbnOTebcQ';
+
+			//set bounds to Texas
+			var bounds = [
+					[-114.9594,21.637], // southwest coords
+					[-85.50,39.317] // northeast coords
+				];
+
+			var map = new mapboxgl.Map({
+				container: 'map', // container id
+				style: 'mapbox://styles/core-gis/cjbcz8eyg70il2snv8ccgahf7', // stylesheet location; this is the style with markers turned OFF
+				center: [-98.887939,31.821565], // starting position [lng, lat]
+				zoom: 5.5, // starting zoom
+				maxBounds: bounds // sets bounds as max
+
+			});
+
+			var originalZoomLevel = map.getZoom();
+
+			function setVisibilityState(params) {
+				if ((params.visibleOnLoad === undefined) || (params.visibleOnLoad === false)) {
+					if ((params.legendID !== undefined) && (params.legendID !== false)) {
+						document.getElementById(params.legendID).classList.add('inactive');
+					}
+					return 'none';
+				} else {
+					if ((params.legendID !== undefined) && (params.legendID !== false)) {
+						document.getElementById(params.legendID).classList.remove('inactive');
+					}
+					return 'visible';
+				}
+			}
+
+			function addPointLayer(map, params) {
+				gus_api(params.gusID, function(jsondata) {
+					var visibilityState = setVisibilityState(params);
+					map.addSource(params.sourceName, {
+						type: 'geojson',
+						data: jsondata
+					});
+					map.addLayer({
+						'id': params.layerName,
+						'type': 'symbol',
+						'source': params.sourceName,
+						'layout': {
+							'icon-image': params.icon,
+							'icon-size': params.iconSize,
+							'icon-allow-overlap': true,
+							'visibility': visibilityState
+						}
+					});
+					map.on("zoomend", function(){
+						map.setLayoutProperty(params.layerName, 'icon-size', (1 + (map.getZoom() / originalZoomLevel - 1) * 2.5) * params.iconSize);
+					});
+				});
+			}
+
+			function addVectorLayer(map, params) {
+				var visibilityState = setVisibilityState(params);
+				map.addSource(params.sourceName, {
+					type: 'vector',
+					url: params.sourceURL
+				});
+				if ((params.lineLayerName !== undefined) && (params.lineLayerName !== false)) {
+					map.addLayer(
+						{
+							'id': params.lineLayerName,
+							'type': 'line',
+							'source': params.sourceName,
+							'source-layer': params.sourceID,
+							'layout': {
+								'visibility': visibilityState,
+								'line-join': 'round',
+								'line-cap': 'round'
+							},
+							'paint': {
+								'line-color': params.lineColor,
+								'line-width': 1
+							},
+						},
+						params.displayBehind
+					);
+				}
+				if ((params.polygonLayerName !== undefined) && (params.polygonLayerName !== false)) {
+					if (params.usedInZoomControl) { visibilityState = 'visible'; }
+					map.addLayer(
+						{
+							'id': params.polygonLayerName,
+							'type': 'fill',
+							'source': params.sourceName,
+							'source-layer': params.sourceID,
+							'layout': {
+								'visibility': visibilityState
+							},
+							'paint': {
+								'fill-color': params.polygonFillColor,
+								'fill-outline-color': params.polygonOutlineColor
+							},
+						}
+					);
+				}
+			}
+
+
+
+/*
+	How to add point layers using the GUS API:
+	Call the addPointLayer() function with arguments like the examples below.
+
+	How to add vector layers using Mapbox:
+	Call the addVectorLayer() function with arguments like the examples below.
+	Note that these calls have to be after the addPointLayer() ones, because they will reference at least one of the point layers as a way of making sure polygons get drawn behind points.
+*/
+
+			map.on('load', function () {
+				addPointLayer(
+					map,
+					{
+						'gusID': "1lW_TLQ25u20FtYMsJIrgWbGvMpdkIVfehZ2wsDa8eck", // Google Sheets ID
+						'sourceName': 'raising-family-partnerships', // this one will be the data source name, used internally
+						'layerName': 'raising-family-partnerships-points', // layer name, used internally
+						'icon': 'raising_family_partnerships_large', // this one will be the icon image name, using the name from Mapbox
+						'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended initial display size, so that when it gets scaled up on zooming in it will still look good
+						'legendID': 'raising_family_partnerships', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate. Simply leave out for layers that don't appear in the legend
+						'visibleOnLoad': false // set the optional final argument to true to have the layer visible on load
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': '1zzDxER2Ef2qMmUg4Ff4zWXoPMQh1RpK4TAueCWqQixE',
+						'sourceName': 'raising-blended-learners',
+						'layerName': 'raising-blended-learners-points',
+						'icon': 'raising_blended_learners_large',
+						'iconSize': 0.1,
+						'legendID': 'raising_blended_learners'
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': "1jlfzTbBwEZVMlkGSJLf9v50vBvHeTJKq13xLus7KbC4",
+						'sourceName': 'charles-butt-scholars',
+						'layerName': 'charles-butt-scholars-points',
+						'icon': 'charles_butt_scholars_large',
+						'iconSize': 0.1,
+						'legendID': 'charles_butt_scholars'
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': "1e24TCpzxcgbSY6CaqDUn4Ll_F36Ttc9341EXEyhpsVs",
+						'sourceName': 'raising-texas-teachers',
+						'layerName': 'raising-texas-teachers-points',
+						'icon': 'raising_texas_teachers_large',
+						'iconSize': 0.1,
+						'legendID': 'raising_texas_teachers'
+					}
+				);
+
+				addPointLayer(
+					map,
+					{
+						'gusID': "1MLMUvg5WXSf3CytsEzEdVPsYPYUb_2nSXsnRnD_7Lj0",
+						'sourceName': 'raising-school-leaders',
+						'layerName': 'raising-school-leaders-points',
+						'icon': 'raising_school_leaders_large',
+						'iconSize': 0.1,
+						'legendID': 'raising_school_leaders'
+					}
+				);
+		/*
+				addPointLayer(
+					map,
+					{
+						'gusID': "1F3qjOKXsK5GTfM_f8RdoQFCJiz6QWDNOQOthJOMQB2g",
+						'sourceName': 'districts-of-innovation',
+						'layerName': 'districts-of-innovation-points',
+						'icon': 'districts_of_innovation_large',
+						'iconSize': 0.1,
+						'legendID': 'districts_of_innovation'
+					}
+				);
+		*/
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'texas-school-districts', // data source name for internal use
+						'sourceID': 'texas_school_districts_v2', // name of the Mapbox layer from which the data will be loaded
+						'sourceURL': 'mapbox://core-gis.e4af0de1', // Mapbox URL
+						'lineLayerName': 'texas-school-districts-lines', // OPTIONAL name we'll use for the layer that shows the outlines. Leave out or set to false if you don't want outlines displayed.
+						'lineColor': '#a1b082', // colour to draw those outlines with; safe to leave out if we're not drawing outlines, but must be explicitly set if we are
+						'legendID': 'texas_school_districts', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate. Simply leave out for layers that don't appear in the legend
+						'displayBehind': 'raising-school-leaders-points', // ID of another existing layer, which Mapbox will make sure this one gets drawn behind
+						'polygonLayerName': 'texas-school-districts-poly', // OPTIONAL name we'll use for the layer that invisibly stores the polygon extents. Needed if we're either going to add this layer to either the zoom to districts control or set click events (e.g. popups) on it.	Leave out or set to false if you don't want one.
+						'polygonFillColor': 'rgba(200, 100, 240, 0)', // colour to fill polygons with. Needed if there's going to be a polygon layer; simply leave out if not.
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)', // colour to draw polygon boundaries with. Needed if there's going to be a polygon layer; simply leave out if not.
+						'visibleOnLoad': false, // set this optional argument to true to have the layer visible on load. Leave out or set to false to have it hidden on load
+						'usedInZoomControl': true // set this optional argument to true if this layer will be used in the Zoom to Districts control, otherwise leave it out or set it to false.
+					}
+				);
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'state-senate-districts',
+						'sourceID': 'state_senate_districts-0g2odu',
+						'sourceURL': 'mapbox://core-gis.b2eu90mx',
+						'lineLayerName': 'state-senate-districts-lines',
+						'lineColor': '#a1b082',
+						'legendID': 'state_senate_districts',
+						'displayBehind': 'raising-school-leaders-points',
+						'polygonLayerName': 'state-senate-districts-poly',
+						'polygonFillColor': 'rgba(200, 100, 240, 0)',
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)',
+						'usedInZoomControl': true
+					}
+				);
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'state-house-districts',
+						'sourceID': 'state_house_districts-1vl4x8',
+						'sourceURL': 'mapbox://core-gis.9drnaiu0',
+						'lineLayerName': 'state-house-districts-lines',
+						'lineColor': 'rgba(117, 137, 77, 0.5)',
+						'legendID': 'state_house_districts',
+						'displayBehind': 'raising-school-leaders-points',
+						'polygonLayerName': 'state-house-districts-poly',
+						'polygonFillColor': 'rgba(200, 100, 240, 0)',
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)',
+						'usedInZoomControl': true
+					}
+				);
+
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'districts-of-innovation-poly',
+						'sourceID': 'districts_of_innovation_poly_v1',
+						'sourceURL': 'mapbox://core-gis.97b01c24',
+						'legendID': 'districts_of_innovation_poly',
+						'displayBehind': 'texas-school-districts-lines',
+						'polygonLayerName': 'districts-of-innovation-poly-fill',
+						'polygonFillColor': 'rgba(247, 247, 198, 100)',
+						'polygonOutlineColor': 'rgba(194, 194, 126, 100)'
+					}
+				);
+
+				// This one's a special case: it's never displayed, but it's used to set what will appear in popups when someone clicks on the map
+				addVectorLayer(
+					map,
+					{
+						'sourceName': 'school_house_senate_districts_UNION',
+						'sourceID': 'school_house_senate_districts_UNION',
+						'sourceURL': 'mapbox://core-gis.a81c8ecf',
+						'displayBehind': 'districts-of-innovation-points',
+						'polygonLayerName': 'school_house_senate_districts_UNION-poly',
+						'polygonFillColor': 'rgba(200, 100, 240, 0)',
+						'polygonOutlineColor': 'rgba(200, 100, 240, 0)',
+						'usedInZoomControl': true
+					}
+				);
+
+				runWhenLoadComplete();
+
+			});
+
+		// This is the popup for the merged boundary layers
+		// When a click event occurs on a feature in the unioned districts layer, open a popup at the
+		// location of the click, with description HTML from its properties.
+			map.on('click', 'school_house_senate_districts_UNION-poly', function (e) {
+				new mapboxgl.Popup()
+					.setLngLat(e.lngLat)
+					.setHTML(fillpopup(e.features[0].properties))
+					.addTo(map);
+			});
+
+			 // Change the cursor to a pointer when the mouse is over the house districts layer.
+				map.on('mouseenter', 'school_house_senate_districts_UNION-poly', function () {
+					map.getCanvas().style.cursor = 'pointer';
+				});
+
+				// Change it back to a pointer when it leaves.
+				map.on('mouseleave', 'school_house_senate_districts_UNION-poly', function () {
+					map.getCanvas().style.cursor = '';
+				});
+
+			function fillpopup(data){
+				var html = "";
+				html = html + "<span class='varname'>School District: </span> <span class='attribute'>" + data.SchDistNam + "</span>";
+				html = html + "<br />"
+				html = html + "<span class='varname'>House District: </span> <span class='attribute'>" + data.HseDistNum + "</span>";
+				html = html + "<br />"
+				html = html + "<span class='varname'>Senate District: </span> <span class='attribute'>" + data.SenDistNum + "</span>";
+				return html;
+				//this will return the string to the calling function
+
+			}
+
+
+
+			function fetchJSONFile(path, callback) {
+				var httpRequest = new XMLHttpRequest();
+				httpRequest.onreadystatechange = function() {
+					if (httpRequest.readyState === 4) {
+						if (httpRequest.status === 200) {
+							var data = JSON.parse(httpRequest.responseText);
+							if (callback) callback(data);
+						}
+					}
+				};
+				httpRequest.open('GET', path);
+				httpRequest.send();
+			}
+
+			function gus_api(id, callback) {
+				const url = `https://spreadsheets.google.com/feeds/cells/${id}/od6/public/basic?alt=json`;
+
+				fetchJSONFile(url, function(data) {
+
+					let headers = {};
+					let entries = {};
+
+					data.feed.entry.forEach((e) => {
+						// get the row number
+						const row = parseInt(e.title['$t'].match(/\d+/g)[0]);
+						const column = e.title['$t'].match(/[a-zA-Z]+/g)[0];
+						const content = e.content['$t'];
+
+						// it's a header
+						if (row === 1) {
+							headers[column] = content;
+						} else {
+							if (!entries[row]) entries[row] = {};
+							entries[row][headers[column]] = content;
+						}
+					});
+
+					const gj = { type: 'FeatureCollection', features: [] };
+					for (let e in entries) {
+
+						const feature = {
+							type: 'Feature',
+							geometry: {
+								type: 'Point',
+								coordinates: [0, 0]
+							},
+							properties: entries[e]
+						};
+
+						for (let p in entries[e]) {
+							switch(p) {
+								case 'longitude':
+								case 'LONGITUDE':
+								case 'long':
+								case 'LONG':
+								case 'lng':
+								case 'LNG':
+								case 'lon':
+								case 'LON':
+								case 'x':
+								case 'X':
+									feature.geometry.coordinates[0] = parseFloat(entries[e][p]);
+								case 'latitude':
+								case 'LATITUDE':
+								case 'lat':
+								case 'LAT':
+								case 'y':
+								case 'Y':
+									feature.geometry.coordinates[1] = parseFloat(entries[e][p]);
+							}
+						}
+
+						gj.features.push(feature);
+					}
+
+					callback(gj);
+				});
+			};
+		</script>
+
+	</body>
+</html>

--- a/icon-and-polygon-demo.html
+++ b/icon-and-polygon-demo.html
@@ -203,7 +203,7 @@
 		<!--
 						<li onClick="showHideLayer('districts-of-innovation-points', markerName='districts_of_innovation');"><span id="districts_of_innovation" class="inactive"></span>Districts of Innovation</li>
 		-->
-						<li onClick="showHideLayer('districts-of-innovation-poly-fill', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly" class="inactive"></span>Districts of Innovation</li>
+						<li onClick="showHideLayer('districts-of-innovation-poly-fill', markerName='districts_of_innovation_poly'); showHideLayer('districts-of-innovation-points', markerName='districts_of_innovation_poly');"><span id="districts_of_innovation_poly" class="inactive"></span>Districts of Innovation</li>
 						<li onClick="showHideLayer('texas-school-districts-lines', markerName='texas_school_districts');"><span id="texas_school_districts" class="inactive"></span>Texas School Districts</li>
 						<li onClick="showHideLayer('state-house-districts-lines', markerName='state_house_districts');"><span id="state_house_districts" class="inactive"></span>State House Districts</li>
 						<li onClick="showHideLayer('state-senate-districts-lines', markerName='state_senate_districts');"><span id="state_senate_districts" class="inactive"></span>State Senate Districts</li>
@@ -390,7 +390,7 @@
 						'legendID': 'raising_school_leaders'
 					}
 				);
-		/*
+
 				addPointLayer(
 					map,
 					{
@@ -399,10 +399,9 @@
 						'layerName': 'districts-of-innovation-points',
 						'icon': 'districts_of_innovation_large',
 						'iconSize': 0.1,
-						'legendID': 'districts_of_innovation'
+						'legendID': 'districts_of_innovation_poly'
 					}
 				);
-		*/
 
 				addVectorLayer(
 					map,


### PR DESCRIPTION
The easiest thing I thought I might try worked nicely.  Take a look at `icon-and-polygon-demo.html` to see the points and polygons for Districts of Innovation playing well together.  All it required was:

1. Defining both a point layer and a vector layer with the same `legendID` set and the same starting visibility.
2. Adding a second `showHideLayer()` call to the `<li>` for Districts of Innovation - both calls use the same `markerName` property, but each uses one of the layers' names.